### PR TITLE
Simplified the indices for multi-task splits and added the split to the checksum

### DIFF
--- a/polaris/benchmark/_definitions.py
+++ b/polaris/benchmark/_definitions.py
@@ -14,21 +14,6 @@ class SingleTaskBenchmarkSpecification(BenchmarkSpecification):
             raise ValueError("A single-task benchmark should specify a single target column")
         return v
 
-    @root_validator(skip_on_failure=True)
-    def validate_single_task_split(cls, values):
-        """
-        A valid single task split assigns inputs exclusively to a single partition.
-        It is not required that the split covers the entirety of a dataset.
-        """
-        v = values["split"]
-        train_indices = v[0]
-        test_indices = [i for part in v[1].values() for i in part] if isinstance(v[1], dict) else v[1]
-        if any(i < 0 or i >= len(values["dataset"]) for i in train_indices + test_indices):
-            raise ValueError("The predefined split contains invalid indices")
-        if any(i in train_indices for i in test_indices):
-            raise ValueError("The predefined split specifies overlapping train and test sets")
-        return values
-
 
 class MultiTaskBenchmarkSpecification(BenchmarkSpecification):
     """Subclass for any multi-task benchmark specification"""
@@ -38,61 +23,3 @@ class MultiTaskBenchmarkSpecification(BenchmarkSpecification):
         if not len(v) > 1:
             raise ValueError("A multi-task benchmark should specify at least two target columns")
         return v
-
-    @staticmethod
-    def check_split_partition(indices: SplitIndicesType, no_datapoints: int, no_targets: int):
-        """Helper method to easily check indices for a single partition."""
-        checked_indices = []
-        for tup in indices:
-            if isinstance(tup, Sequence):
-                invalid = (
-                    len(tup) != 2
-                    or tup[0] < 0
-                    or tup[0] >= no_datapoints
-                    or any(i < 0 for i in tup[1])
-                    or any(i >= no_targets for i in tup[1])
-                )
-            elif isinstance(tup, int):
-                # With single index, we assume all targets are indexed.
-                # This simplifies split definitions, because you can specify X instead of (X, 1), (X, 2), ...
-                # Changing the index here to a consistent format for downstream processing.
-                invalid = tup < 0 or tup >= no_datapoints
-                tup = (tup, list(range(no_targets)))
-
-            else:
-                invalid = True
-
-            if invalid:
-                raise ValueError("The predefined split contains invalid indices")
-
-            checked_indices.append(tup)
-
-        return checked_indices
-
-    @root_validator(skip_on_failure=True)
-    def validate_multi_task_split(cls, values):
-        """
-        A valid multitask split assigns each input, target pair exclusively to a single partition.
-        It is not required that the split covers the entirety of a dataset.
-        """
-        # Extract the relevant data
-        v = values["split"]
-        no_datapoints = len(values["dataset"])
-        no_targets = len(values["target_cols"])
-
-        # Check the train set
-        train_pairs = cls.check_split_partition(v[0], no_datapoints, no_targets)
-
-        # Check the test sets and whether any of them overlap with train
-        if isinstance(v[1], dict):
-            test_pairs = {k: cls.check_split_partition(v, no_datapoints, no_targets) for k, v in v[1].items()}
-            overlapping = any(tup in train_pairs for subset in test_pairs.values() for tup in subset)
-        else:
-            test_pairs = cls.check_split_partition(v[1], no_datapoints, no_targets)
-            overlapping = any(tup in train_pairs for tup in test_pairs)
-
-        if overlapping:
-            raise ValueError("The predefined split specifies overlapping train and test sets")
-
-        values["split"] = train_pairs, test_pairs
-        return values

--- a/polaris/dataset/_subset.py
+++ b/polaris/dataset/_subset.py
@@ -139,11 +139,9 @@ class Subset:
         idx = self.indices[item]
 
         # Get the row from the base table
-        row_idx = idx[0] if self.is_multi_task else idx
-        row = self.dataset.table.iloc[row_idx]
+        row = self.dataset.table.iloc[idx]
 
         # Load the input modalities
-        # NOTE (cwognum): We currently do not support splits across inputs, so we do not need to do any indexing.
         ins = {col: self.dataset.get_data(row.name, col) for col in self.input_cols}
         ins = self._convert(ins, self.input_cols, self._input_format)
 
@@ -153,12 +151,7 @@ class Subset:
             return ins
 
         # Retrieve the targets
-        target_idx = self.target_cols
-        if self.is_multi_task:
-            target_idx = [target_idx[i] for i in idx[1]]
-
-        # If in a multi-task setting a target is missing due to indexing, we return the np NaN.
-        outs = {c: row[c] if c in target_idx else np.nan for c in self.target_cols}
+        outs = {col: self.dataset.get_data(row.name, col) for col in self.target_cols}
         outs = self._convert(outs, self.target_cols, self._target_format)
 
         return ins, outs

--- a/polaris/evaluate/_metric.py
+++ b/polaris/evaluate/_metric.py
@@ -1,6 +1,7 @@
 from typing import Callable
 from sklearn.metrics import (
     mean_absolute_error as sklearn_mae,
+    mean_squared_error as sklearn_mse,
     accuracy_score as sklearn_acc,
 )
 
@@ -35,6 +36,10 @@ class Metric:
         """Singleton access to an already registered metric"""
         return METRICS_REGISTRY[name]
 
+    @staticmethod
+    def list_supported_metrics():
+        return sorted(list(METRICS_REGISTRY.keys()))
+
     def score(self, y_true, y_pred):
         """Compute the metric"""
         return self.fn(y_true, y_pred)
@@ -48,4 +53,5 @@ class Metric:
 #  - Add support for more metrics
 #  - Any preprocessing needed? For example changing the shape / dtype? Converting from torch tensors or lists?
 mean_absolute_error = Metric("mean_absolute_error", sklearn_mae)
+mean_squared_error = Metric("mean_squared_error", sklearn_mse)
 accuracy = Metric("accuracy", sklearn_acc)

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -2,20 +2,32 @@ import numpy as np
 from typing_extensions import TypeAlias
 from typing import List, Tuple, Union, Dict, Any
 
-# A split is defined by a sequence of integers (single-task) or by a sequence of integer pairs (multi-task)
-SplitIndicesType: TypeAlias = List[Union[int, Tuple[int, Union[List[int], int]]]]
 
-# A split is a pair of which the first item is always assumed to be the train set.
-# The second item can either be a single test set or a dictionary with multiple, named test sets.
+"""
+A split is defined by a sequence of integers.
+"""
+SplitIndicesType: TypeAlias = List[int]
+
+
+"""
+A split is a pair of which the first item is always assumed to be the train set.
+The second item can either be a single test set or a dictionary with multiple, named test sets.
+"""
 SplitType: TypeAlias = Tuple[SplitIndicesType, Union[SplitIndicesType, Dict[str, SplitIndicesType]]]
 
-# A prediction is one of three things:
-# - A single array (single-task, single test set)
-# - A dictionary of arrays (single-task, multiple test sets)
-# - A dictionary of dictionaries of arrays (multi-task, multiple test sets)
+
+"""
+A prediction is one of three things:
+  - A single array (single-task, single test set)
+  - A dictionary of arrays (single-task, multiple test sets) 
+  - A dictionary of dictionaries of arrays (multi-task, multiple test sets)
+"""
 PredictionsType: TypeAlias = Union[np.ndarray, Dict[str, Union[np.ndarray, Dict[str, np.ndarray]]]]
 
-# A datapoint has:
-# - A single input or multiple inputs (either as dict or tuple)
-# - No target, a single target or a multiple targets (either as dict or tuple)
+
+"""
+A datapoint has:
+  - A single input or multiple inputs (either as dict or tuple)
+  - No target, a single target or a multiple targets (either as dict or tuple)
+"""
 DatapointType: TypeAlias = Tuple[Union[Any, Tuple, Dict[str, Any]], Union[Any, Tuple, Dict[str, Any]]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def test_single_task_benchmark(test_dataset):
     test_indices = list(range(90, 100))
     return SingleTaskBenchmarkSpecification(
         dataset=test_dataset,
-        metrics=["mean_absolute_error"],
+        metrics=["mean_absolute_error", "mean_squared_error"],
         split=(train_indices, test_indices),
         target_cols="expt",
         input_cols="smiles",
@@ -58,8 +58,8 @@ def test_single_task_benchmark(test_dataset):
 @pytest.fixture(scope="module")
 def test_multi_task_benchmark(test_dataset):
     # For the sake of simplicity, just use a small set of indices
-    train_indices = [0, (1, [0])]
-    test_indices = [(1, [1]), 2]
+    train_indices = list(range(90))
+    test_indices = list(range(90, 100))
     return MultiTaskBenchmarkSpecification(
         dataset=test_dataset,
         metrics=["mean_absolute_error"],

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,110 +4,53 @@ from pydantic import ValidationError
 from polaris import load_benchmark
 from polaris.dataset import SingleTaskBenchmarkSpecification, MultiTaskBenchmarkSpecification, Subset
 from polaris.utils import fs
+from polaris.utils.errors import PolarisChecksumError
 
 
-def test_single_task_benchmark_split_verification(test_single_task_benchmark):
+@pytest.mark.parametrize("is_single_task", [True, False])
+def test_split_verification(is_single_task, test_single_task_benchmark, test_multi_task_benchmark):
+    obj = test_single_task_benchmark if is_single_task else test_multi_task_benchmark
+    cls = SingleTaskBenchmarkSpecification if is_single_task else MultiTaskBenchmarkSpecification
+
     # By using the fixture as a default, we know it doesn't always fail
     default_kwargs = {
-        "dataset": test_single_task_benchmark.dataset,
-        "target_cols": test_single_task_benchmark.target_cols,
-        "input_cols": test_single_task_benchmark.input_cols,
-        "metrics": test_single_task_benchmark.metrics,
+        "dataset": obj.dataset,
+        "target_cols": obj.target_cols,
+        "input_cols": obj.input_cols,
+        "metrics": obj.metrics,
     }
 
-    train_split = test_single_task_benchmark.split[0]
-    test_split = test_single_task_benchmark.split[1]
+    train_split = obj.split[0]
+    test_split = obj.split[1]
 
     # One or more empty partitions
     with pytest.raises(ValidationError):
-        SingleTaskBenchmarkSpecification(split=(train_split,), **default_kwargs)
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(split=(train_split, []), **default_kwargs)
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(split=(train_split, {"test": []}), **default_kwargs)
+        cls(split=(train_split,), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split, []), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split, {"test": []}), **default_kwargs)
     # Non-exclusive partitions
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(split=(train_split, test_split + train_split[:1]), **default_kwargs)
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(
-            split=(train_split, {"test1": test_split, "test2": train_split[:1]}), **default_kwargs
-        )
+    with pytest.raises(ValidationError):
+        cls(split=(train_split, test_split + train_split[:1]), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split, {"test1": test_split, "test2": train_split[:1]}), **default_kwargs)
     # Invalid indices
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(
-            split=(train_split + [len(test_single_task_benchmark.dataset)], test_split), **default_kwargs
-        )
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(split=(train_split + [-1], test_split), **default_kwargs)
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(
-            split=(train_split, test_split + [len(test_single_task_benchmark.dataset)]), **default_kwargs
-        )
-    with pytest.raises(ValueError):
-        SingleTaskBenchmarkSpecification(split=(train_split, test_split + [-1]), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split + [len(obj.dataset)], test_split), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split + [-1], test_split), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split, test_split + [len(obj.dataset)]), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split, test_split + [-1]), **default_kwargs)
+    # Duplicate indices
+    with pytest.raises(ValidationError):
+        cls(split=(train_split + train_split[:1], test_split), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(split=(train_split, test_split + test_split[:1]), **default_kwargs)
     # It should _not_ fail with missing indices
-    SingleTaskBenchmarkSpecification(split=(train_split[:-1], test_split), **default_kwargs)
-
-
-def test_multi_task_benchmark_split_verification(test_multi_task_benchmark):
-    # By using the fixture as a default, we know it doesn't always fail
-    default_kwargs = {
-        "dataset": test_multi_task_benchmark.dataset,
-        "target_cols": test_multi_task_benchmark.target_cols,
-        "input_cols": test_multi_task_benchmark.input_cols,
-        "metrics": test_multi_task_benchmark.metrics,
-    }
-
-    train_split = test_multi_task_benchmark.split[0]
-    test_split = test_multi_task_benchmark.split[1]
-
-    # One or more empty partitions
-    with pytest.raises(ValidationError):
-        MultiTaskBenchmarkSpecification(split=(train_split,), **default_kwargs)
-    with pytest.raises(ValidationError):
-        MultiTaskBenchmarkSpecification(split=(train_split, []), **default_kwargs)
-    with pytest.raises(ValidationError):
-        MultiTaskBenchmarkSpecification(split=(train_split, {"test": []}), **default_kwargs)
-    # Non-exclusive partitions
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(split=(train_split, test_split + train_split[:1]), **default_kwargs)
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(
-            split=(train_split, {"test1": test_split, "test2": train_split[:1]}), **default_kwargs
-        )
-    # This should not fail (overlapping molecule, different targets)
-    MultiTaskBenchmarkSpecification(
-        split=(train_split + [(5, [0])], test_split + [(5, [1])]), **default_kwargs
-    )
-    # Invalid indices
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(split=(train_split + [(-1, [0])], test_split), **default_kwargs)
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(split=(train_split + [(0, [-1])], test_split), **default_kwargs)
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(split=(train_split, test_split + [(-1, [0])]), **default_kwargs)
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(split=(train_split, test_split + [(0, [-1])]), **default_kwargs)
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(
-            split=(train_split + [(len(test_multi_task_benchmark.dataset), [0])], test_split),
-            **default_kwargs,
-        )
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(
-            split=(train_split + [(0, [len(test_multi_task_benchmark.dataset)])], test_split),
-            **default_kwargs,
-        )
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(
-            split=(train_split, test_split + [(len(test_multi_task_benchmark.dataset), [0])]),
-            **default_kwargs,
-        )
-    with pytest.raises(ValueError):
-        MultiTaskBenchmarkSpecification(
-            split=(train_split, test_split + [(0, [len(test_multi_task_benchmark.dataset)])]),
-            **default_kwargs,
-        )
+    cls(split=(train_split[:-1], test_split), **default_kwargs)
 
 
 @pytest.mark.parametrize("cls", [SingleTaskBenchmarkSpecification, MultiTaskBenchmarkSpecification])
@@ -179,3 +122,65 @@ def test_benchmark_from_yaml(test_single_task_benchmark, tmpdir):
 
     new_benchmark = load_benchmark(path)
     assert new_benchmark == test_single_task_benchmark
+
+
+@pytest.mark.parametrize("is_single_task", [True, False])
+def test_benchmark_checksum(is_single_task, test_single_task_benchmark, test_multi_task_benchmark):
+    obj = test_single_task_benchmark if is_single_task else test_multi_task_benchmark
+    cls = SingleTaskBenchmarkSpecification if is_single_task else MultiTaskBenchmarkSpecification
+
+    original = obj.md5sum
+    assert original is not None
+
+    # --- Test that the checksum is the same with insignificant changes ---
+
+    # Without any changes, same hash
+    kwargs = obj.dict()
+    cls(**kwargs)
+
+    # With a different ordering of the target columns
+    kwargs["target_cols"] = kwargs["target_cols"][::-1]
+    cls(**kwargs)
+
+    # With a different ordering of the metrics
+    kwargs["metrics"] = kwargs["metrics"][::-1]
+    cls(**kwargs)
+
+    # With a different ordering of the split
+    kwargs["split"] = kwargs["split"][::-1]
+    cls(**kwargs)
+
+    # --- Test that the checksum is NOT the same ---
+    def _check_for_failure(_kwargs):
+        with pytest.raises(ValidationError) as error:
+            cls(**_kwargs)
+            assert error.error_count() == 1  # noqa
+            assert isinstance(error.errors()[0], PolarisChecksumError)  # noqa
+
+    # Split
+    kwargs = obj.dict()
+    kwargs["split"] = kwargs["split"][0][1:] + [-1], kwargs["split"][1]
+    _check_for_failure(kwargs)
+
+    kwargs = obj.dict()
+    kwargs["split"] = kwargs["split"][0], kwargs["split"][1][1:] + [-1]
+    _check_for_failure(kwargs)
+
+    # Metrics
+    kwargs = obj.dict()
+    kwargs["metrics"] = kwargs["metrics"][1:] + ["accuracy"]
+    _check_for_failure(kwargs)
+
+    # Target columns
+    kwargs = obj.dict()
+    kwargs["target_cols"] = kwargs["target_cols"][1:] + ["iupac"]
+    _check_for_failure(kwargs)
+
+    kwargs = obj.dict()
+    kwargs["input_cols"] = kwargs["input_cols"][1:] + ["iupac"]
+    _check_for_failure(kwargs)
+
+    # --- Don't fail if not checksum is provided ---
+    kwargs["md5sum"] = None
+    dataset = cls(**kwargs)
+    assert dataset.md5sum is not None


### PR DESCRIPTION
## Changelogs

- Closes #10 by simplifying the multi-task indices from `List[Tuple[int, List[int]]]` to `List[int]` and adds the split to the MD5 checksum of the `BenchmarkSpecification`.

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [x] _Update the API documentation is a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---


