### PR TITLE
Fixes bugs in loading `Dataset` from a `.zarr` and in the use of pointer columns

### DIFF
--- a/polaris/benchmark/_definitions.py
+++ b/polaris/benchmark/_definitions.py
@@ -1,7 +1,4 @@
-from typing import Sequence
-
-from pydantic import validator, root_validator
-from polaris.utils.types import SplitIndicesType
+from pydantic import validator
 from polaris.benchmark import BenchmarkSpecification
 
 

--- a/polaris/dataset/_column.py
+++ b/polaris/dataset/_column.py
@@ -1,7 +1,7 @@
 import enum
 from typing import Optional, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, validator
 
 
 class Modality(enum.Enum):

--- a/polaris/dataset/_subset.py
+++ b/polaris/dataset/_subset.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Union, List, Sequence, Tuple, Any, Dict, Literal, Optional
+from typing import Union, List, Sequence, Literal, Optional
 from polaris.dataset import Dataset
 from polaris.utils.context import tmp_attribute_change
 from polaris.utils.errors import TestAccessError

--- a/polaris/evaluate/_results.py
+++ b/polaris/evaluate/_results.py
@@ -50,7 +50,7 @@ class BenchmarkResults(BaseModel):
     """
     The time-stamp at which the results were created. Automatically set.
     """
-    _created_at: datetime = Field(default_factory=datetime.now)
+    _created_at: datetime = PrivateAttr(default_factory=datetime.now)
 
     @validator("results")
     def validate_results(cls, v):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,9 @@ def test_zarr_archive(tmp_path):
     root = zarr.open_group(tmp_path, mode="w")
     group_a = root.create_group("A/")
     group_b = root.create_group("B/")
-    group_a.array("data", data=np.random.random((100, 2048)))
-    group_b.array("data", data=np.random.random((100, 2048)))
-    root.attrs["C"] = {"data": 0.0}
+    group_a.array(0, data=np.random.random((100, 2048)))
+    group_b.array(0, data=np.random.random((100, 2048)))
+    root.attrs["C"] = {0: 0.0}
     root.attrs["name"] = "Test"
     root.attrs["description"] = "Go wild in your test cases with this awesome dataset"
     root.attrs["source"] = "Imagination"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -34,7 +34,7 @@ def test_load_data(modality, tmp_path):
     assert (data == arr).all()
 
     # With caching
-    dataset.download()
+    dataset.cache()
     data = dataset.get_data(row=0, col="A")
     assert (data == arr).all()
 
@@ -81,9 +81,10 @@ def test_dataset_checksum(test_dataset):
 
 def test_dataset_from_zarr(test_zarr_archive):
     dataset = Dataset.from_zarr(test_zarr_archive)
-    assert dataset.get_data("data", "A").shape == (100, 2048)
-    assert dataset.get_data("data", "B").shape == (100, 2048)
-    assert dataset.get_data("data", "C") == 0.0
+    assert len(dataset.table) == 100
+    assert dataset.get_data(row=0, col="A").shape == (2048,)
+    assert dataset.get_data(row=0, col="B").shape == (2048,)
+    assert dataset.get_data(row=0, col="C") == 0.0
 
 
 def test_dataset_from_yaml(test_dataset, tmpdir):


### PR DESCRIPTION
## Changelogs

- Makes it possible to construct a `Dataset` from a single `zarr` array (instead of having a `zarr` array per datapoint). This is done by adding a `index` suffix to the path (e.g. `/path/to/array.zarr#0`).
- Fix several bugs in working with pointer columns. 

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

