### PR TITLE
Added a README field to the benchmark and dataset classes

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -63,10 +63,14 @@ class BenchmarkSpecification(BaseArtifactModel):
         main_metric: The main metric used to rank methods. If `None`, the first of the `metrics` field.
         md5sum: The checksum is used to verify the version of the dataset specification. If specified, it will
             raise an error if the specified checksum doesn't match the computed checksum.
+        readme: Markdown text that can be used to provide a formatted description of the benchmark.
+            If using the Polaris Hub, it is worth noting that this field is more easily edited through the Hub UI
+            as it provides a rich text editor for writing markdown.
     For additional meta-data attributes, see the [`BaseArtifactModel`][polaris._artifact.BaseArtifactModel] class.
     """
 
     # Public attributes
+    # Data
     dataset: Union[Dataset, str, dict[str, Any]]
     target_cols: ColumnsType
     input_cols: ColumnsType
@@ -74,6 +78,9 @@ class BenchmarkSpecification(BaseArtifactModel):
     metrics: Union[str, Metric, list[Union[str, Metric]]]
     main_metric: Optional[Union[str, Metric]] = None
     md5sum: Optional[str] = None
+
+    # Additional meta-data
+    readme: str = ""
 
     # Pydantic config
     model_config = ConfigDict(

--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -50,6 +50,9 @@ class Dataset(BaseArtifactModel):
             path to a `.parquet` file or a `pandas.DataFrame`.
         md5sum: The checksum is used to verify the version of the dataset specification. If specified, it will
             raise an error if the specified checksum doesn't match the computed checksum.
+        readme: Markdown text that can be used to provide a formatted description of the dataset.
+            If using the Polaris Hub, it is worth noting that this field is more easily edited through the Hub UI
+            as it provides a rich text editor for writing markdown.
         annotations: Each column _can be_ annotated with a [`ColumnAnnotation`][polaris.dataset.ColumnAnnotation] object.
             Importantly, this is used to annotate whether a column is a pointer column.
         source: The data source, e.g. a DOI, Github repo or URI.
@@ -66,6 +69,7 @@ class Dataset(BaseArtifactModel):
     md5sum: Optional[str] = None
 
     # Additional meta-data
+    readme: str = ""
     annotations: Dict[str, ColumnAnnotation] = Field(default_factory=dict)
     source: Optional[HttpUrlString] = None
     license: Optional[License] = None


### PR DESCRIPTION
## Changelogs

Closes #37 

- Added a `readme` field to the `Dataset` and `BenchmarkSpecification` classes.

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

I considered two additional improvements, but didn't end up implementing these: 
- Show the formatted `readme` in Jupyter Notebooks for the respective representations. This is possible through `IPython.display`. However, I didn't want to go down the rabbit hole of improving the visual representation of these classes as I could quickly see this take up a lot of time and because it is not a priority as of now. 
- I looked around a bit for a more constrained type-hint than just a plain string, but I don't think there is a straight-forward answer (can you even distinguish normal strings from markdown strings with absolute certainty?).