### PR TITLE
Refactor the structure of a saved result to be easier for building benchmarks

### DIFF
--- a/polaris/evaluate/_metric.py
+++ b/polaris/evaluate/_metric.py
@@ -3,21 +3,19 @@ from typing import Callable
 
 import numpy as np
 from pydantic import BaseModel, Field
+from scipy import stats
 from sklearn.metrics import (
     accuracy_score,
+    average_precision_score,
+    cohen_kappa_score,
+    explained_variance_score,
+    f1_score,
+    matthews_corrcoef,
     mean_absolute_error,
     mean_squared_error,
     r2_score,
-    explained_variance_score,
-)
-from sklearn.metrics import (
-    f1_score,
-    matthews_corrcoef,
     roc_auc_score,
-    average_precision_score,
-    cohen_kappa_score,
 )
-from scipy import stats
 
 from polaris.utils.types import DirectionType
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -14,7 +14,7 @@ def test_result_to_json(tmpdir: str, test_user_owner: HubOwner):
         {
             "Test set": ["A", "A", "A", "A", "B", "B", "B", "B"],
             "Target label": ["C", "C", "D", "D", "C", "C", "D", "D"],
-            "Metric": ["E", "F"] * 4,
+            "Metric": ["mean_absolute_error", "accuracy"] * 4,
             "Score": [0.1] * 8,
         }
     )


### PR DESCRIPTION
## Changelogs

- Changed the structure of how we serialize the `BenchmarkResults.results` field

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
