### PR TITLE
fix: Use the Parquet file size and checksum for the table content metadata when creating a dataset on the Hub

### DIFF
--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -2,7 +2,15 @@ import json
 from typing import Dict, Optional, Union
 
 import fsspec
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    computed_field,
+    field_serializer,
+    field_validator,
+)
 from pydantic.alias_generators import to_camel
 
 from polaris.utils.types import HubOwner, SlugCompatibleStringType

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -1,9 +1,8 @@
 import json
 import os
 import ssl
-import sys
 import webbrowser
-from hashlib import md5, sha256
+from hashlib import md5
 from io import BytesIO
 from typing import Callable, Optional, Union
 from urllib.parse import urljoin
@@ -301,7 +300,7 @@ class PolarisHubClient(OAuth2Client):
         response = self._base_request_to_hub(
             url="/dataset", method="GET", params={"limit": limit, "offset": offset}
         )
-        dataset_list = [bm['artifactId'] for bm in response["data"]]
+        dataset_list = [bm["artifactId"] for bm in response["data"]]
         return dataset_list
 
     def get_dataset(self, owner: Union[str, HubOwner], name: str) -> Dataset:
@@ -453,15 +452,19 @@ class PolarisHubClient(OAuth2Client):
         # Step 1: Upload meta-data
         # Instead of directly uploading the table, we announce to the hub that we intend to upload one.
         url = f"/dataset/{dataset.artifact_id}"
-        response = self._base_request_to_hub(url=url, method="PUT", json={
-            "tableContent": {
-                "size": parquet_size,
-                "fileType": "parquet",
-                "md5sum": parquet_md5,
+        response = self._base_request_to_hub(
+            url=url,
+            method="PUT",
+            json={
+                "tableContent": {
+                    "size": parquet_size,
+                    "fileType": "parquet",
+                    "md5sum": parquet_md5,
+                },
+                "access": access,
+                **dataset_json,
             },
-            "access": access,
-            **dataset_json,
-        })
+        )
 
         # Step 2: Upload the parquet file
         # create an empty PUT request to get the table content URL from cloudflare


### PR DESCRIPTION
# Changelogs

This PR updates the file size and checksum set as metadata on a dataset's table content to use the Parquet file's attributes. This will let the Hub correctly check the size of the uploaded file and 
set the state of the dataset to **ready**. 

# Links

- Closes [#201](https://github.com/polaris-hub/polaris-hub/issues/201)

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- ~[ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- ~[ ] _Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

