### PR TITLE
Minor: Change 'all' to 'aggregated'

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -346,7 +346,7 @@ class BenchmarkSpecification(BaseArtifactModel):
                 if metric.is_multitask:
                     # Multi-task but with a metric across targets
                     score = metric(y_true=y_true_subset, y_pred=y_pred[test_label])
-                    scores.loc[len(scores)] = (test_label, "all", metric, score)
+                    scores.loc[len(scores)] = (test_label, "aggregated", metric, score)
                     continue
 
                 if not isinstance(y_true_subset, dict):


### PR DESCRIPTION
## Changelogs

- Change the 'all' label for metrics that aggregated across tasks to 'aggregated'. 
   - For more context, see https://github.com/polaris-hub/polaris-hub/pull/227

