### PR TITLE
remove nans

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -209,12 +209,16 @@ class BenchmarkSpecification(BaseArtifactModel):
 
         dataset = info.data.get("dataset")
         target_cols = info.data.get("target_cols")
+        splits = np.concatenate(info.data["split"])
+
         if dataset is None or target_cols is None:
             return v
 
         for target in target_cols:
             if target not in v:
-                target_type = type_of_target(dataset[:, target])
+                val = dataset[splits, target]
+                # remove the nans for mutiple task dataset when the table is sparse
+                target_type = type_of_target(val[~np.isnan(val)])
                 if target_type == "continuous":
                     v[target] = TargetType.REGRESSION
                 elif target_type in ["binary", "multiclass"]:


### PR DESCRIPTION
This is to solve the issue when validate and compute `type_of_target` for datasets containing NaNs (for the  sparse datasets with multi targets).

## Changelogs
- Remove nans from dataset when check the target type. 

