### PR TITLE
feature: polaris fsspec basic read only implementation

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -10,24 +10,6 @@ on:
       - "!gh-pages"
 
 jobs:
-  python-format-black:
-    name: Python format [black]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the code
-        uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
-      - name: Install black
-        run: |
-          pip install black>=23
-
-      - name: Format
-        run: black --check .
 
   python-lint-ruff:
     name: Python lint [ruff]
@@ -47,3 +29,6 @@ jobs:
 
       - name: Lint
         run: ruff .
+
+      - name: Format
+        run: ruff format . --check

--- a/docs/api/hub.polarisfs.md
+++ b/docs/api/hub.polarisfs.md
@@ -1,4 +1,4 @@
-::: polaris.hub.polarisfs.PolarisFS
+::: polaris.hub.polarisfs.PolarisFileSystem
     options: 
         merge_init_into_class: true
         filters: ["!^_"]

--- a/docs/api/hub.polarisfs.md
+++ b/docs/api/hub.polarisfs.md
@@ -1,5 +1,5 @@
-::: polaris.hub.polarisfs.PolarisFSFileSystem
+::: polaris.hub.polarisfs.PolarisFS
     options: 
         merge_init_into_class: true
-        filters: ["!^_", "!create_authorization_url", "!fetch_token", "!request", "!token"]
+        filters: ["!^_"]
 ---

--- a/docs/api/hub.polarisfs.md
+++ b/docs/api/hub.polarisfs.md
@@ -1,0 +1,5 @@
+::: polaris.hub.polarisfs.PolarisFSFileSystem
+    options: 
+        merge_init_into_class: true
+        filters: ["!^_", "!create_authorization_url", "!fetch_token", "!request", "!token"]
+---

--- a/env.yml
+++ b/env.yml
@@ -40,7 +40,6 @@ dependencies:
   - pytest
   - pytest-xdist
   - pytest-cov
-  - black >=23
   - ruff
   - jupyterlab
   - ipywidgets

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
           - Evaluation: api/evaluation.md
       - Hub:
           - Client: api/hub.client.md
+          - PolarisFS: api/hub.polarisfs.md
       - Additional:
           - Base classes: api/base.md
           - Types: api/utils.types.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ nav:
           - Evaluation: api/evaluation.md
       - Hub:
           - Client: api/hub.client.md
-          - PolarisFS: api/hub.polarisfs.md
+          - PolarisFileSystem: api/hub.polarisfs.md
       - Additional:
           - Base classes: api/base.md
           - Types: api/utils.types.md

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -354,7 +354,9 @@ class PolarisHubClient(OAuth2Client):
             store = zarr.storage.FSStore(path, fs=polaris_fs)
             return zarr.open(store, mode="r")
         except TimeoutError as timeout_error:
-            raise PolarisHubError(f"Timeout error: {timeout_error}. Consider increasing the expiration_seconds parameter and try again.")
+            raise PolarisHubError(
+                f"Timeout error: {timeout_error}. Consider increasing the expiration_seconds parameter and try again."
+            )
         except Exception as e:
             raise PolarisHubError(f"Error opening Zarr store: {e}")
 

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -28,7 +28,7 @@ from polaris.benchmark import (
 from polaris.dataset import Dataset
 from polaris.evaluate import BenchmarkResults
 from polaris.hub.settings import PolarisHubSettings
-from polaris.hub.polarisfs import PolarisFSFileSystem
+from polaris.hub.polarisfs import PolarisFS
 from polaris.utils import fs
 from polaris.utils.constants import DEFAULT_CACHE_DIR
 from polaris.utils.errors import PolarisHubError, PolarisUnauthorizedError
@@ -344,7 +344,7 @@ class PolarisHubClient(OAuth2Client):
         Returns:
             The Zarr object representing the dataset.
         """
-        polaris_fs = PolarisFSFileSystem(
+        polaris_fs = PolarisFS(
             polaris_client=self,
             dataset_owner=owner,
             dataset_name=name,
@@ -354,11 +354,9 @@ class PolarisHubClient(OAuth2Client):
             store = zarr.storage.FSStore(path, fs=polaris_fs)
             return zarr.open(store, mode="r")
         except TimeoutError as timeout_error:
-            raise PolarisHubError(
-                f"Timeout error: {timeout_error}. Consider increasing the expiration_seconds parameter and try again."
-            )
+            raise PolarisHubError(f"Timeout error.") from timeout_error
         except Exception as e:
-            raise PolarisHubError(f"Error opening Zarr store: {e}")
+            raise PolarisHubError(f"Error opening Zarr store") from e
 
     def list_benchmarks(self, limit: int = 100, offset: int = 0) -> list[str]:
         """List all available benchmarks on the Polaris Hub.

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -346,15 +346,15 @@ class PolarisHubClient(OAuth2Client):
         """
         polaris_fs = PolarisFSFileSystem(
             polaris_client=self,
-            polarisfs_url=str(self.base_url), 
+            polarisfs_url=str(self.base_url),
             default_expirations_seconds=10 * 60,
             dataset_owner=owner,
-            dataset_name=name
+            dataset_name=name,
         )
 
         try:
             store = zarr.storage.FSStore(path, fs=polaris_fs)
-            return zarr.open(store, mode="r")            
+            return zarr.open(store, mode="r")
         except Exception as e:
             raise PolarisHubError(f"Error opening Zarr store: {e}")
 

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -303,35 +303,6 @@ class PolarisHubClient(OAuth2Client):
         )
         dataset_list = [bm["artifactId"] for bm in response["data"]]
         return dataset_list
-    
-    def list_objects_in_path(self, **kwargs):
-        return self._base_request_to_hub(url=f"/storage/dataset/polaris/hello-world/ls/data.zarr", 
-            method="GET")
-
-    def read_zarr_file(self, owner: str, name: str, path: str, **kwargs):
-        """Read a Zarr file from a Polaris dataset
-
-        Args:
-            owner: Which Hub user or organization owns the artifact.
-            name: Name of the dataset.
-            path: Path to the Zarr file within the dataset.
-
-        Returns:
-            zarr.hierarchy.Group: The Zarr object representing the dataset.
-        """
-        polaris_fs = PolarisFSFileSystem(
-            polaris_client=self,
-            polarisfs_url=str(self.base_url), 
-            default_expirations_seconds=10 * 60,
-            dataset_owner=owner,
-            dataset_name=name
-        )
-
-        try:
-            store = zarr.storage.FSStore(path, fs=polaris_fs)
-            return zarr.open(store, mode="r")            
-        except Exception as e:
-            raise PolarisHubError(f"Error opening Zarr store: {e}")
 
     def get_dataset(self, owner: Union[str, HubOwner], name: str) -> Dataset:
         """Load a dataset from the Polaris Hub.
@@ -361,6 +332,31 @@ class PolarisHubClient(OAuth2Client):
         response["table"] = self._load_from_signed_url(url=url, headers=headers, load_fn=pd.read_parquet)
 
         return Dataset(**response)
+
+    def read_zarr_file(self, owner: str, name: str, path: str, **kwargs):
+        """Read a Zarr file from a Polaris dataset
+
+        Args:
+            owner: Which Hub user or organization owns the artifact.
+            name: Name of the dataset.
+            path: Path to the Zarr file within the dataset.
+
+        Returns:
+            zarr.hierarchy.Group: The Zarr object representing the dataset.
+        """
+        polaris_fs = PolarisFSFileSystem(
+            polaris_client=self,
+            polarisfs_url=str(self.base_url), 
+            default_expirations_seconds=10 * 60,
+            dataset_owner=owner,
+            dataset_name=name
+        )
+
+        try:
+            store = zarr.storage.FSStore(path, fs=polaris_fs)
+            return zarr.open(store, mode="r")            
+        except Exception as e:
+            raise PolarisHubError(f"Error opening Zarr store: {e}")
 
     def list_benchmarks(self, limit: int = 100, offset: int = 0) -> list[str]:
         """List all available benchmarks on the Polaris Hub.

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -24,7 +24,7 @@ class PolarisFileSystem(fsspec.AbstractFileSystem):
         ```python
         fs = PolarisFileSystem(...)
         store = zarr.storage.FSStore(..., fs=polaris_fs)
-        return zarr.open(store, mode="r")
+        root = zarr.open(store, mode="r")
         ```
 
     Args:

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -6,6 +6,7 @@ from polaris.utils.errors import PolarisHubError
 
 from httpx._types import TimeoutTypes
 
+
 class PolarisFSFileSystem(fsspec.AbstractFileSystem):
     """
     A file system interface for accessing datasets on the Polaris platform.
@@ -42,10 +43,12 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
 
         # Prefix to remove from ls entries
         self.prefix = f"dataset/{dataset_owner}/{dataset_name}/"
-        self.base_path = f"/storage/{self.prefix}"  
+        self.base_path = f"/storage/{self.prefix}"
 
-    def ls(self, path: str, detail: bool = False, timeout: TimeoutTypes = (10, 200), **kwargs: dict) -> Union[List[str], List[Dict[str, Any]]]:
-        """ List objects in the specified path within the Polaris dataset.
+    def ls(
+        self, path: str, detail: bool = False, timeout: TimeoutTypes = (10, 200), **kwargs: dict
+    ) -> Union[List[str], List[Dict[str, Any]]]:
+        """List objects in the specified path within the Polaris dataset.
 
         Args:
             path: The path within the dataset to list objects.
@@ -62,23 +65,25 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
         response.raise_for_status()
 
         if not detail:
-            entries = [p["name"][len(self.prefix):] for p in response.json()]
+            entries = [p["name"][len(self.prefix) :] for p in response.json()]
             return entries
         else:
             detailed_entries = [
-                {"name": p["name"][len(self.prefix):], "size": p["size"], "type": p["type"]}
+                {"name": p["name"][len(self.prefix) :], "size": p["size"], "type": p["type"]}
                 for p in response.json()
             ]
             return detailed_entries
 
-    def cat_file(self, path: str, start: int = None, end: int = None, timeout: TimeoutTypes = (10, 200), **kwargs: dict) -> bytes:
-        """ Fetches and returns the content of a file from the Polaris dataset.
+    def cat_file(
+        self, path: str, start: int = None, end: int = None, timeout: TimeoutTypes = (10, 200), **kwargs: dict
+    ) -> bytes:
+        """Fetches and returns the content of a file from the Polaris dataset.
 
         Args:
             path: The path to the file within the dataset.
             start: The starting index of the content to retrieve.
             end: The ending index of the content to retrieve.
-            timeout: Maximum time (in seconds) to wait for the request to complete. 
+            timeout: Maximum time (in seconds) to wait for the request to complete.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -93,7 +98,7 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
         if response.status_code != 307:
             raise PolarisHubError("Could not get signed URL from Polaris Hub.")
 
-        storage_response = self.polaris_client.get(response.json()["url"], auth=None,  timeout=timeout)
+        storage_response = self.polaris_client.get(response.json()["url"], auth=None, timeout=timeout)
         storage_response.raise_for_status()
 
         return storage_response.content[start:end]

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -3,8 +3,12 @@ from typing import Union
 
 import fsspec
 import httpx
+from polaris.utils.httpx import _log_response
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from polaris.utils.errors import PolarisHubError
+# from polaris.hub.client import PolarisHubClient
 
 class PolarisfsSettings(BaseSettings):
     url: str = "http://localhost:3000/api/v1"
@@ -17,7 +21,7 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
     protocol = "polarisfs"
     async_impl = False
 
-    def __init__(self, polarisfs_url: Optional[str], default_expirations_seconds: int = 10 * 60, **kwargs):
+    def __init__(self, polaris_client, polarisfs_url: Optional[str], default_expirations_seconds: int = 10 * 60, **kwargs):
         super().__init__(**kwargs)
 
         # NOTE(hadim): ugly I know xD
@@ -28,9 +32,41 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
 
         self.default_expirations_seconds = default_expirations_seconds
 
+        self.polaris_client = polaris_client 
         self.http_client = httpx.Client(base_url=self.settings.url)
         self.http_fs = fsspec.filesystem("http")
+        self.base_path = "/storage/dataset"
 
-    def ls(self, polarisfs_path="storage/dataset/polaris-test/__test/ls/zarr_test_archives/1GB_many_arrays.zarr/data.zarr/", **kwargs):
-        resp = self.http_client.get(polarisfs_path)
-        return resp.json()['response']
+    def ls(self, path: str, detail=False, **kwargs):
+
+        full_path = f"{self.base_path}/polaris/hello-world/ls/{path}"
+
+        print("ls path: ", full_path.rstrip("/"))
+        response = self.polaris_client.get(full_path.rstrip("/"), params={})
+        
+        response.raise_for_status()
+
+        if not detail:
+            entries = [p["name"][28:] for p in response.json()]
+            print(entries)
+            return entries
+        else:
+            detailed_entries = [{"name": p["name"][28:], "size": p["size"], "type": p["type"]} for p in response.json()]
+            print(detailed_entries)
+            return detailed_entries
+
+
+    def cat(self, path:str, recursive=False, **kwargs):
+        full_path=f"{self.base_path}/polaris/hello-world/{path}"
+
+        response = self.polaris_client.get(full_path, params={})
+
+        if response.status_code != 307:
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as error:
+                raise PolarisHubError("Could not get signed URL from Polaris Hub.") from error
+
+        storage_response = self.http_client.get(response.json()["url"])
+
+        return storage_response.json()

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Union
 
 import fsspec
 import httpx
@@ -7,6 +6,7 @@ import httpx
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from polaris.utils.errors import PolarisHubError
+
 
 class PolarisfsSettings(BaseSettings):
     url: str = "http://localhost:3000/"
@@ -19,13 +19,15 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
     protocol = "polarisfs"
     async_impl = False
 
-    def __init__(self, 
-                polaris_client, 
-                polarisfs_url: Optional[str],
-                dataset_owner: str,
-                dataset_name: str,
-                default_expirations_seconds: int = 10 * 60, 
-                **kwargs):
+    def __init__(
+        self,
+        polaris_client,
+        polarisfs_url: Optional[str],
+        dataset_owner: str,
+        dataset_name: str,
+        default_expirations_seconds: int = 10 * 60,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
 
         if polarisfs_url is None:
@@ -35,7 +37,7 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
 
         self.default_expirations_seconds = default_expirations_seconds
 
-        self.polaris_client = polaris_client 
+        self.polaris_client = polaris_client
 
         self.http_client = httpx.Client(base_url=self.settings.url)
         self.http_fs = fsspec.filesystem("http")
@@ -56,11 +58,14 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
             entries = [p["name"].replace(self.prefix, "") for p in response.json()]
             return entries
         else:
-            detailed_entries = [{"name": p["name"].replace(self.prefix, ""), "size": p["size"], "type": p["type"]} for p in response.json()]
+            detailed_entries = [
+                {"name": p["name"].replace(self.prefix, ""), "size": p["size"], "type": p["type"]}
+                for p in response.json()
+            ]
             return detailed_entries
 
-    def cat_file(self, path:str, **kwargs):
-        cat_path=f"{self.base_path}/{path}"
+    def cat_file(self, path: str, **kwargs):
+        cat_path = f"{self.base_path}/{path}"
 
         # GET request to Polaris Hub for signed URL of file
         response = self.polaris_client.get(cat_path, params={})

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -1,82 +1,99 @@
-from typing import Optional
-
 import fsspec
-import httpx
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import Union, List, Dict, Any
 
 from polaris.utils.errors import PolarisHubError
 
-
-class PolarisfsSettings(BaseSettings):
-    url: str = "http://localhost:3000/"
-
-    model_config = SettingsConfigDict(env_prefix="POLARIS_")
-
+from httpx._types import TimeoutTypes
 
 class PolarisFSFileSystem(fsspec.AbstractFileSystem):
+    """
+    A file system interface for accessing datasets on the Polaris platform.
+
+    This class extends `fsspec.AbstractFileSystem` and provides methods to list objects within a Polaris dataset
+    and fetch the content of a file from the dataset.
+
+    Note: Zarr Integration
+        This file system can be used with Zarr for working with multidimensional array data stored in the Polaris dataset.
+
+    Args:
+        polaris_client: The Polaris Hub client used to make API requests.
+        dataset_owner: The owner of the dataset.
+        dataset_name: The name of the dataset.
+        default_expirations_seconds: Default expiration time for signed URLs.
+        **kwargs: Additional keyword arguments.
+    """
+
     sep = "/"
     protocol = "polarisfs"
     async_impl = False
 
     def __init__(
         self,
-        polaris_client,
-        polarisfs_url: Optional[str],
+        polaris_client: Any,
         dataset_owner: str,
         dataset_name: str,
         default_expirations_seconds: int = 10 * 60,
-        **kwargs,
+        **kwargs: dict,
     ):
         super().__init__(**kwargs)
 
-        if polarisfs_url is None:
-            self.settings = PolarisfsSettings()
-        else:
-            self.settings = PolarisfsSettings(url=polarisfs_url)
-
-        self.default_expirations_seconds = default_expirations_seconds
-
         self.polaris_client = polaris_client
-
-        self.http_client = httpx.Client(base_url=self.settings.url)
-        self.http_fs = fsspec.filesystem("http")
-
-        self.base_path = f"/storage/dataset/{dataset_owner}/{dataset_name}"
 
         # Prefix to remove from ls entries
         self.prefix = f"dataset/{dataset_owner}/{dataset_name}/"
+        self.base_path = f"/storage/{self.prefix}"  
 
-    def ls(self, path: str, detail=False, **kwargs):
-        ls_path = f"{self.base_path}/ls/{path}"
+    def ls(self, path: str, detail: bool = False, timeout: TimeoutTypes = (10, 200), **kwargs: dict) -> Union[List[str], List[Dict[str, Any]]]:
+        """ List objects in the specified path within the Polaris dataset.
+
+        Args:
+            path: The path within the dataset to list objects.
+            detail: If True, returns detailed information about each object.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A list of dictionaries if detail is True; otherwise, a list of object names.
+        """
+        ls_path = f"{self.base_path}ls/{path}"
 
         # GET request to Polaris Hub to list objects in path
-        response = self.polaris_client.get(ls_path.rstrip("/"), params={})
+        response = self.polaris_client.get(ls_path.rstrip("/"), timeout=timeout)
         response.raise_for_status()
 
         if not detail:
-            entries = [p["name"].replace(self.prefix, "") for p in response.json()]
+            entries = [p["name"][len(self.prefix):] for p in response.json()]
             return entries
         else:
             detailed_entries = [
-                {"name": p["name"].replace(self.prefix, ""), "size": p["size"], "type": p["type"]}
+                {"name": p["name"][len(self.prefix):], "size": p["size"], "type": p["type"]}
                 for p in response.json()
             ]
             return detailed_entries
 
-    def cat_file(self, path: str, **kwargs):
-        cat_path = f"{self.base_path}/{path}"
+    def cat_file(self, path: str, start: int = None, end: int = None, timeout: TimeoutTypes = (10, 200), **kwargs: dict) -> bytes:
+        """ Fetches and returns the content of a file from the Polaris dataset.
+
+        Args:
+            path: The path to the file within the dataset.
+            start: The starting index of the content to retrieve.
+            end: The ending index of the content to retrieve.
+            timeout: Maximum time (in seconds) to wait for the request to complete. 
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The content of the requested file.
+        """
+        cat_path = f"{self.base_path}{path}"
 
         # GET request to Polaris Hub for signed URL of file
-        response = self.polaris_client.get(cat_path, params={})
+        response = self.polaris_client.get(cat_path)
 
         # This should be a 307 redirect with the signed URL
         if response.status_code != 307:
-            try:
-                response.raise_for_status()
-            except httpx.HTTPStatusError as error:
-                raise PolarisHubError("Could not get signed URL from Polaris Hub.") from error
+            raise PolarisHubError("Could not get signed URL from Polaris Hub.")
 
-        storage_response = self.http_client.get(response.json()["url"], timeout=(10, 200))
+        storage_response = self.polaris_client.get(response.json()["url"], auth=None,  timeout=timeout)
+        storage_response.raise_for_status()
 
-        return storage_response.content
+        return storage_response.content[start:end]

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -1,0 +1,36 @@
+from typing import Optional
+from typing import Union
+
+import fsspec
+import httpx
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class PolarisfsSettings(BaseSettings):
+    url: str = "http://localhost:3000/api/v1"
+
+    model_config = SettingsConfigDict(env_prefix="POLARIS_")
+
+
+class PolarisFSFileSystem(fsspec.AbstractFileSystem):
+    sep = "/"
+    protocol = "polarisfs"
+    async_impl = False
+
+    def __init__(self, polarisfs_url: Optional[str], default_expirations_seconds: int = 10 * 60, **kwargs):
+        super().__init__(**kwargs)
+
+        # NOTE(hadim): ugly I know xD
+        if polarisfs_url is None:
+            self.settings = PolarisfsSettings()
+        else:
+            self.settings = PolarisfsSettings(url=polarisfs_url)
+
+        self.default_expirations_seconds = default_expirations_seconds
+
+        self.http_client = httpx.Client(base_url=self.settings.url)
+        self.http_fs = fsspec.filesystem("http")
+
+    def ls(self, polarisfs_path="storage/dataset/polaris-test/__test/ls/zarr_test_archives/1GB_many_arrays.zarr/data.zarr/", **kwargs):
+        resp = self.http_client.get(polarisfs_path)
+        return resp.json()['response']

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -3,15 +3,13 @@ from typing import Union
 
 import fsspec
 import httpx
-from polaris.utils.httpx import _log_response
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from polaris.utils.errors import PolarisHubError
-# from polaris.hub.client import PolarisHubClient
 
 class PolarisfsSettings(BaseSettings):
-    url: str = "http://localhost:3000/api/v1"
+    url: str = "http://localhost:3000/"
 
     model_config = SettingsConfigDict(env_prefix="POLARIS_")
 
@@ -21,10 +19,15 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
     protocol = "polarisfs"
     async_impl = False
 
-    def __init__(self, polaris_client, polarisfs_url: Optional[str], default_expirations_seconds: int = 10 * 60, **kwargs):
+    def __init__(self, 
+                polaris_client, 
+                polarisfs_url: Optional[str],
+                dataset_owner: str,
+                dataset_name: str,
+                default_expirations_seconds: int = 10 * 60, 
+                **kwargs):
         super().__init__(**kwargs)
 
-        # NOTE(hadim): ugly I know xD
         if polarisfs_url is None:
             self.settings = PolarisfsSettings()
         else:
@@ -33,40 +36,42 @@ class PolarisFSFileSystem(fsspec.AbstractFileSystem):
         self.default_expirations_seconds = default_expirations_seconds
 
         self.polaris_client = polaris_client 
+
         self.http_client = httpx.Client(base_url=self.settings.url)
         self.http_fs = fsspec.filesystem("http")
-        self.base_path = "/storage/dataset"
+
+        self.base_path = f"/storage/dataset/{dataset_owner}/{dataset_name}"
+
+        # Prefix to remove from ls entries
+        self.prefix = f"dataset/{dataset_owner}/{dataset_name}/"
 
     def ls(self, path: str, detail=False, **kwargs):
+        ls_path = f"{self.base_path}/ls/{path}"
 
-        full_path = f"{self.base_path}/polaris/hello-world/ls/{path}"
-
-        print("ls path: ", full_path.rstrip("/"))
-        response = self.polaris_client.get(full_path.rstrip("/"), params={})
-        
+        # GET request to Polaris Hub to list objects in path
+        response = self.polaris_client.get(ls_path.rstrip("/"), params={})
         response.raise_for_status()
 
         if not detail:
-            entries = [p["name"][28:] for p in response.json()]
-            print(entries)
+            entries = [p["name"].replace(self.prefix, "") for p in response.json()]
             return entries
         else:
-            detailed_entries = [{"name": p["name"][28:], "size": p["size"], "type": p["type"]} for p in response.json()]
-            print(detailed_entries)
+            detailed_entries = [{"name": p["name"].replace(self.prefix, ""), "size": p["size"], "type": p["type"]} for p in response.json()]
             return detailed_entries
 
+    def cat_file(self, path:str, **kwargs):
+        cat_path=f"{self.base_path}/{path}"
 
-    def cat(self, path:str, recursive=False, **kwargs):
-        full_path=f"{self.base_path}/polaris/hello-world/{path}"
+        # GET request to Polaris Hub for signed URL of file
+        response = self.polaris_client.get(cat_path, params={})
 
-        response = self.polaris_client.get(full_path, params={})
-
+        # This should be a 307 redirect with the signed URL
         if response.status_code != 307:
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as error:
                 raise PolarisHubError("Could not get signed URL from Polaris Hub.") from error
 
-        storage_response = self.http_client.get(response.json()["url"])
+        storage_response = self.http_client.get(response.json()["url"], timeout=(10, 200))
 
-        return storage_response.json()
+        return storage_response.content

--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -4,7 +4,9 @@ from urllib.parse import urljoin
 from pydantic import FieldValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from polaris.utils.types import HttpUrlString
+from polaris.utils.types import HttpUrlString, TimeoutTypes
+
+# from httpx._types import TimeoutTypes
 
 
 class PolarisHubSettings(BaseSettings):
@@ -37,6 +39,8 @@ class PolarisHubSettings(BaseSettings):
     scopes: str = "profile email"
     client_id: str = "QJg8zadGwjnr6nbN"
     ca_bundle: Optional[Union[str, bool]] = None
+
+    default_timeout: TimeoutTypes = (10, 200)
 
     # Configuration of the pydantic model
     model_config = SettingsConfigDict(env_prefix="POLARIS_")

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Annotated, Any, ClassVar, Literal, Optional, Union
+from typing import Annotated, Any, ClassVar, Literal, Optional, Union, Tuple
 
 import fsspec
 import numpy as np
@@ -85,6 +85,11 @@ This can be used to sort the metric score, indicate the optmization direction of
 AccessType: TypeAlias = Literal["public", "private"]
 """
 Type to specify access to a dataset, benchmark or result in the Hub.
+"""
+
+TimeoutTypes = Union[Tuple[int, int], Literal["timeout", "never"]]
+"""
+Timeout types for specifying maximum wait times.
 """
 
 

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Annotated, Any, ClassVar, Literal, Optional, Union, Tuple
+from typing import Annotated, Any, ClassVar, Literal, Optional, Tuple, Union
 
 import fsspec
 import numpy as np
@@ -10,7 +10,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     HttpUrl,
-    constr,
+    StringConstraints,
     model_validator,
 )
 from pydantic.alias_generators import to_camel
@@ -50,12 +50,16 @@ DataFormat: TypeAlias = Literal["dict", "tuple"]
 The target formats that are supported by the `Subset` class. 
 """
 
-SlugStringType: TypeAlias = constr(pattern="^[a-z0-9-]+$", min_length=4, max_length=64)
+SlugStringType: TypeAlias = Annotated[
+    str, StringConstraints(pattern="^[a-z0-9-]+$", min_length=4, max_length=64)
+]
 """
 A URL-compatible string that can serve as slug on the hub.
 """
 
-SlugCompatibleStringType: TypeAlias = constr(pattern="^[A-Za-z0-9_-]+$", min_length=4, max_length=64)
+SlugCompatibleStringType: TypeAlias = Annotated[
+    str, StringConstraints(pattern="^[A-Za-z0-9_-]+$", min_length=4, max_length=64)
+]
 """
 A URL-compatible string that can be turned into a slug by the hub.
 

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -115,9 +115,9 @@ class License(BaseModel):
             Else it is required to manually specify this.
     """
 
-    SPDX_LICENSE_DATA_PATH: ClassVar[str] = (
-        "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
-    )
+    SPDX_LICENSE_DATA_PATH: ClassVar[
+        str
+    ] = "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
 
     id: str
     reference: Optional[HttpUrlString] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,6 @@ include = ["polaris", "polaris.*"]
 exclude = []
 namespaces = false
 
-[tool.black]
-line-length = 110
-target-version = ['py310', 'py311']
-include = '\.pyi?$'
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--verbose --durations=10 -n auto --cov=polaris --cov-fail-under=75 --cov-report xml --cov-report term"
@@ -106,13 +101,13 @@ omit = [
 output = "coverage.xml"
 
 [tool.ruff]
-ignore = [
+lint.ignore = [
     "E501", # Never enforce `E501` (line length violations).
 ]
 line-length = 110
 target-version = "py310"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = [
     "F401", # imported but unused
     "E402", # Module level import not at top of file


### PR DESCRIPTION
## Changelogs

Integrated a read-only version of [Hadrien's POC](https://github.com/polaris-hub/polaris-fs/blob/main/polarisfs/client/fs.py) for the Polaris FSSpec. Some of the major changes include:
- Added a new endpoint in the client to be able to read the zarr file of a dataset.
- Added a new submodule in the hub folder, `polarisfs.py` which contains the FSSpec.
- For read-only implementation, the FSSpec currently supports the `ls` and `cat_file` operations.

#### More details of the FSSpec Implementation:
- The `ls` function makes a GET request to the Hub's api storage ls endpoint which returns an array of dictionaries, containing the files and directories within a given path in the Cloudflare R2 bucket.
- In the `ls` function, the prefix is required to be removed from each entry as the path provided to the Zarr store contains only the `{path}/...`, and not the `dataset/{owner}/{name}/{path}...`
- The `cat_file` makes a GET request to the Hub's api storage endpoint to obtain a signed URL for a given path and follows the redirect to obtain the contents of the file.
- The `cat_file` needed to have an specified timeout to avoid ending prematurely for larger sized zarr files

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._



Linked to: https://github.com/polaris-hub/polaris-hub/pull/276