### PR TITLE
feature: polaris fsspec write implementation

### DIFF
--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -32,7 +32,7 @@ from polaris.hub.settings import PolarisHubSettings
 from polaris.utils import fs
 from polaris.utils.constants import DEFAULT_CACHE_DIR
 from polaris.utils.errors import PolarisHubError, PolarisUnauthorizedError
-from polaris.utils.types import AccessType, HubOwner, TimeoutTypes
+from polaris.utils.types import AccessType, HubOwner, TimeoutTypes, IOMode
 
 _HTTPX_SSL_ERROR_CODE = "[SSL: CERTIFICATE_VERIFY_FAILED]"
 
@@ -334,7 +334,7 @@ class PolarisHubClient(OAuth2Client):
         return Dataset(**response)
 
     def open_zarr_file(
-        self, owner: Union[str, HubOwner], name: str, path: str, mode: str
+        self, owner: Union[str, HubOwner], name: str, path: str, mode: IOMode
     ) -> zarr.hierarchy.Group:
         """Open a Zarr file from a Polaris dataset
 
@@ -342,7 +342,7 @@ class PolarisHubClient(OAuth2Client):
             owner: Which Hub user or organization owns the artifact.
             name: Name of the dataset.
             path: Path to the Zarr file within the dataset.
-            mode: The mode in which the file is opened ('r' for read-only, 'w' for write).
+            mode: The mode in which the file is opened.
 
         Returns:
             The Zarr object representing the dataset.

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -175,7 +175,7 @@ class PolarisFileSystem(fsspec.AbstractFileSystem):
         if timeout is None:
             timeout = self.default_timeout
 
-        pipe_path = self.sep.join([self.base_path, "put", path])
+        pipe_path =  self.sep.join([self.base_path, path])
 
         # PUT request to Polaris Hub to put object in path
         response = self.polaris_client.put(pipe_path, timeout=timeout, content=content)

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -130,7 +130,7 @@ class PolarisFileSystem(fsspec.AbstractFileSystem):
             data = f.read()
         return data[start:end]
 
-    def rm(self, path: str, recursive: bool = False, maxdepth: Optional[int] = None)  -> None :
+    def rm(self, path: str, recursive: bool = False, maxdepth: Optional[int] = None) -> None:
         """Remove a file or directory from the Polaris dataset.
 
         This method is provided for compatibility with the Zarr storage interface.
@@ -170,7 +170,7 @@ class PolarisFileSystem(fsspec.AbstractFileSystem):
         if timeout is None:
             timeout = self.default_timeout
 
-        pipe_path =  self.sep.join([self.base_path, path])
+        pipe_path = self.sep.join([self.base_path, path])
 
         # PUT request to Polaris Hub to put object in path
         response = self.polaris_client.put(pipe_path, timeout=timeout, content=content)

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
-import datetime
+from datetime import datetime, timezone
 import fsspec
 import hashlib
 
@@ -186,7 +186,7 @@ class PolarisFileSystem(fsspec.AbstractFileSystem):
         headers = {
             "Content-Type": "application/octet-stream",
             "x-amz-content-sha256": sha256_hash,
-            "x-amz-date": datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ"),
+            "x-amz-date": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
             **hub_response_body["headers"],
         }
 

--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import datetime
 import fsspec
 import hashlib
-import time
-
 
 from polaris.utils.errors import PolarisHubError
 from polaris.utils.types import TimeoutTypes
@@ -150,10 +148,7 @@ class PolarisFileSystem(fsspec.AbstractFileSystem):
             This method currently it does not perform any removal operations and is included
             as a placeholder that aligns with the Zarr interface's expectations.
         """
-        try:
-            raise NotImplementedError("PolarisFS does not currently support the file removal operation.")
-        except NotImplementedError as e:
-            print(f"NotImplementedError: {e}")
+        raise NotImplementedError("PolarisFS does not currently support the file removal operation.")
 
     def pipe_file(
         self,

--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -30,10 +30,12 @@ class PolarisHubSettings(BaseSettings):
             Allows for custom SSL certificates to be used.
     """
 
-    hub_url: HttpUrlString = "https://polarishub.io/"
+    hub_url: HttpUrlString = "http://localhost:3000/"  # "https://polarishub.io/"
     api_url: Optional[HttpUrlString] = None
     authorize_url: HttpUrlString = "https://pure-whippet-77.clerk.accounts.dev/oauth/authorize"
-    callback_url: HttpUrlString = "https://polarishub.io/oauth2/callback"
+    callback_url: HttpUrlString = (
+        "http://localhost:3000/oauth2/callback"  # "https://polarishub.io/oauth2/callback"
+    )
     token_fetch_url: HttpUrlString = "https://pure-whippet-77.clerk.accounts.dev/oauth/token"
     user_info_url: HttpUrlString = "https://pure-whippet-77.clerk.accounts.dev/oauth/userinfo"
     scopes: str = "profile email"

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -21,13 +21,17 @@ SplitIndicesType: TypeAlias = list[int]
 A split is defined by a sequence of integers.
 """
 
-SplitType: TypeAlias = tuple[SplitIndicesType, Union[SplitIndicesType, dict[str, SplitIndicesType]]]
+SplitType: TypeAlias = tuple[
+    SplitIndicesType, Union[SplitIndicesType, dict[str, SplitIndicesType]]
+]
 """
 A split is a pair of which the first item is always assumed to be the train set.
 The second item can either be a single test set or a dictionary with multiple, named test sets.
 """
 
-PredictionsType: TypeAlias = Union[np.ndarray, dict[str, Union[np.ndarray, dict[str, np.ndarray]]]]
+PredictionsType: TypeAlias = Union[
+    np.ndarray, dict[str, Union[np.ndarray, dict[str, np.ndarray]]]
+]
 """
 A prediction is one of three things:
 
@@ -96,6 +100,10 @@ TimeoutTypes = Union[Tuple[int, int], Literal["timeout", "never"]]
 Timeout types for specifying maximum wait times.
 """
 
+IOMode: TypeAlias = Literal["r", "r+", "a", "w", "w-"]
+"""
+Type to specify the mode for input/output operations (I/O) when interacting with a file or resource.
+"""
 
 class HubOwner(BaseModel):
     """An owner of an artifact on the Polaris Hub
@@ -146,7 +154,9 @@ class License(BaseModel):
 
         if m.id in data:
             if m.reference is not None and m.reference != data[m.id]["reference"]:
-                logger.warning(f"Found license ID {m.id} in SPDX, using the associated reference.")
+                logger.warning(
+                    f"Found license ID {m.id} in SPDX, using the associated reference."
+                )
             m.reference = data[m.id]["reference"]
 
         if m.id not in data and m.reference is None:

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -21,17 +21,13 @@ SplitIndicesType: TypeAlias = list[int]
 A split is defined by a sequence of integers.
 """
 
-SplitType: TypeAlias = tuple[
-    SplitIndicesType, Union[SplitIndicesType, dict[str, SplitIndicesType]]
-]
+SplitType: TypeAlias = tuple[SplitIndicesType, Union[SplitIndicesType, dict[str, SplitIndicesType]]]
 """
 A split is a pair of which the first item is always assumed to be the train set.
 The second item can either be a single test set or a dictionary with multiple, named test sets.
 """
 
-PredictionsType: TypeAlias = Union[
-    np.ndarray, dict[str, Union[np.ndarray, dict[str, np.ndarray]]]
-]
+PredictionsType: TypeAlias = Union[np.ndarray, dict[str, Union[np.ndarray, dict[str, np.ndarray]]]]
 """
 A prediction is one of three things:
 
@@ -105,6 +101,7 @@ IOMode: TypeAlias = Literal["r", "r+", "a", "w", "w-"]
 Type to specify the mode for input/output operations (I/O) when interacting with a file or resource.
 """
 
+
 class HubOwner(BaseModel):
     """An owner of an artifact on the Polaris Hub
 
@@ -154,9 +151,7 @@ class License(BaseModel):
 
         if m.id in data:
             if m.reference is not None and m.reference != data[m.id]["reference"]:
-                logger.warning(
-                    f"Found license ID {m.id} in SPDX, using the associated reference."
-                )
+                logger.warning(f"Found license ID {m.id} in SPDX, using the associated reference.")
             m.reference = data[m.id]["reference"]
 
         if m.id not in data and m.reference is None:


### PR DESCRIPTION
## Changelogs

Integrated a basic write implementation for Zarr files with the Polaris FSSpec. Some of the major changes include:
- Added a new endpoint in the client to be able to write a zarr file of a Polaris dataset.
- Added two new methods in the FSSpec: `rm` and `pipe_file`

#### More details of the FSSpec Implementation:
- The `rm` method is currently added as placeholder since it's required for the Zarr writing integration. 
- The `pipe_file` method calls the hub to get a signed URL for a PUT request, then writes the data to the bucket. The S3 bucket uses SHA-256 for data security but it is currently set to None.

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---
