### PR TITLE
Hotfix: Added option to disable the checksum verification

### DIFF
--- a/polaris/loader/load.py
+++ b/polaris/loader/load.py
@@ -11,7 +11,7 @@ from polaris.hub.client import PolarisHubClient
 from polaris.utils import fs
 
 
-def load_dataset(path: str) -> Dataset:
+def load_dataset(path: str, verify_checksum: bool = True) -> Dataset:
     """
     Loads a Polaris dataset.
 
@@ -35,14 +35,14 @@ def load_dataset(path: str) -> Dataset:
     if not is_file:
         # Load from the Hub
         client = PolarisHubClient()
-        return client.get_dataset(*path.split("/"))
+        return client.get_dataset(*path.split("/"), verify_checksum=verify_checksum)
 
     if extension == "json":
         return Dataset.from_json(path)
     return create_dataset_from_file(path)
 
 
-def load_benchmark(path: str):
+def load_benchmark(path: str, verify_checksum: bool = True):
     """
     Loads a Polaris benchmark.
 
@@ -66,7 +66,7 @@ def load_benchmark(path: str):
     if not is_file:
         # Load from the Hub
         client = PolarisHubClient()
-        return client.get_benchmark(*path.split("/"))
+        return client.get_benchmark(*path.split("/"), verify_checksum=verify_checksum)
 
     with fsspec.open(path, "r") as fd:
         data = json.load(fd)


### PR DESCRIPTION
## Changelogs

- Added the `verify_checksum` parameter to `load_dataset` and `load_benchmark`.
---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

 https://github.com/polaris-hub/polaris/pull/77 changed how the checksum is computed, which created errors when loading a dataset or benchmark from the hub. More generally, I think the checksum can be a little brittle so having a way to disable it seems good.
