### PR TITLE
Added the version attribute to the artifact data model

### DIFF
--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -47,7 +47,7 @@ class BaseArtifactModel(BaseModel):
     tags: list[str] = Field(default_factory=list)
     user_attributes: Dict[str, str] = Field(default_factory=dict)
     owner: Optional[HubOwner] = None
-    version: str = Field(po.__version__)
+    version: str = po.__version__
 
     @computed_field
     @property

--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -15,7 +15,7 @@ from pydantic import (
 from pydantic.alias_generators import to_camel
 
 import polaris as po
-from polaris.utils.misc import sluggify
+from polaris.utils.misc import sluggify, str_to_version
 from polaris.utils.types import HubOwner, SlugCompatibleStringType
 
 
@@ -47,9 +47,7 @@ class BaseArtifactModel(BaseModel):
     tags: list[str] = Field(default_factory=list)
     user_attributes: Dict[str, str] = Field(default_factory=dict)
     owner: Optional[HubOwner] = None
-    version: Optional[Union[str, Version]] = Field(
-        default_factory=lambda: Version(po.__version__) if po.__version__ != "dev" else None
-    )
+    version: Optional[Union[str, Version]] = Field(default_factory=lambda: str_to_version(po.__version__))
 
     @computed_field
     @property
@@ -59,12 +57,11 @@ class BaseArtifactModel(BaseModel):
     @field_validator("version")
     @classmethod
     def _validate_version(cls, value: Union[str, Version]):
-        current_version = Version(po.__version__)
+        current_version = str_to_version(po.__version__)
         if value is None:
             value = current_version
         elif isinstance(value, str):
-            if value != "dev":
-                value = Version(value)
+            value = str_to_version(value)
 
         if value is not None and value != current_version:
             logger.info(

--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -47,7 +47,7 @@ class BaseArtifactModel(BaseModel):
     tags: list[str] = Field(default_factory=list)
     user_attributes: Dict[str, str] = Field(default_factory=dict)
     owner: Optional[HubOwner] = None
-    version: Optional[str] = Field(po.__version__)
+    version: str = Field(po.__version__)
 
     @computed_field
     @property
@@ -56,13 +56,12 @@ class BaseArtifactModel(BaseModel):
 
     @field_validator("version")
     @classmethod
-    def _validate_version(cls, value: Optional[str]) -> str:
-        current_version = po.__version__
-        if value is None:
-            value = current_version
-        elif isinstance(value, str) and value != "dev":
-            Version(value)  # Make sure it is a valid semantic version
+    def _validate_version(cls, value: str) -> str:
+        if value != "dev":
+            # Make sure it is a valid semantic version
+            Version(value)
 
+        current_version = po.__version__
         if value != current_version:
             logger.info(
                 f"The version of Polaris that was used to create the artifact ({value}) is different "
@@ -76,10 +75,6 @@ class BaseArtifactModel(BaseModel):
         if isinstance(value, str):
             return HubOwner(slug=value)
         return value
-
-    @field_serializer("version")
-    def _serialize_version(self, value: Version) -> str:
-        return str(value)
 
     @field_serializer("owner")
     def _serialize_owner(self, value: HubOwner) -> Union[str, None]:

--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -47,7 +47,9 @@ class BaseArtifactModel(BaseModel):
     tags: list[str] = Field(default_factory=list)
     user_attributes: Dict[str, str] = Field(default_factory=dict)
     owner: Optional[HubOwner] = None
-    version: Union[str, Version] = Field(default_factory=lambda: Version(po.__version__))
+    version: Optional[Union[str, Version]] = Field(
+        default_factory=lambda: Version(po.__version__) if po.__version__ != "dev" else None
+    )
 
     @computed_field
     @property
@@ -61,9 +63,10 @@ class BaseArtifactModel(BaseModel):
         if value is None:
             value = current_version
         elif isinstance(value, str):
-            value = Version(value)
+            if value != "dev":
+                value = Version(value)
 
-        if value != current_version:
+        if value is not None and value != current_version:
             logger.info(
                 f"The Polaris version that was used to create the artifact ({value}) is different from "
                 f"the currently installed version of Polaris ({current_version})."

--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -15,7 +15,7 @@ from pydantic import (
 from pydantic.alias_generators import to_camel
 
 import polaris as po
-from polaris.utils.misc import sluggify, str_to_version
+from polaris.utils.misc import sluggify
 from polaris.utils.types import HubOwner, SlugCompatibleStringType
 
 
@@ -47,7 +47,7 @@ class BaseArtifactModel(BaseModel):
     tags: list[str] = Field(default_factory=list)
     user_attributes: Dict[str, str] = Field(default_factory=dict)
     owner: Optional[HubOwner] = None
-    version: Optional[Union[str, Version]] = Field(default_factory=lambda: str_to_version(po.__version__))
+    version: Optional[str] = Field(po.__version__)
 
     @computed_field
     @property
@@ -56,20 +56,18 @@ class BaseArtifactModel(BaseModel):
 
     @field_validator("version")
     @classmethod
-    def _validate_version(cls, value: Union[str, Version]):
-        current_version = str_to_version(po.__version__)
+    def _validate_version(cls, value: Optional[str]) -> str:
+        current_version = po.__version__
         if value is None:
             value = current_version
-        elif isinstance(value, str):
-            value = str_to_version(value)
+        elif isinstance(value, str) and value != "dev":
+            Version(value)  # Make sure it is a valid semantic version
 
-        if value is not None and value != current_version:
+        if value != current_version:
             logger.info(
-                f"The Polaris version that was used to create the artifact ({value}) is different from "
-                f"the currently installed version of Polaris ({current_version})."
+                f"The version of Polaris that was used to create the artifact ({value}) is different "
+                f"from the currently installed version of Polaris ({current_version})."
             )
-        if not isinstance(value, Version):
-            raise ValueError(f"Version must be a string or Version object. Got: {type(value)}")
         return value
 
     @field_validator("owner", mode="before")

--- a/polaris/utils/misc.py
+++ b/polaris/utils/misc.py
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, Literal
+
+from packaging.version import Version
 
 from polaris.utils.types import SlugCompatibleStringType
 
@@ -16,3 +18,12 @@ def sluggify(sluggable: SlugCompatibleStringType):
     Converts a string to a slug-compatible string.
     """
     return sluggable.lower().replace("_", "-")
+
+
+def str_to_version(value: str) -> Version | Literal["dev"]:
+    """
+    Convert a string to a Version object if possible, unless it is 'dev'
+    """
+    if value == "dev":
+        return "dev"
+    return Version(value)

--- a/polaris/utils/misc.py
+++ b/polaris/utils/misc.py
@@ -1,6 +1,4 @@
-from typing import Any, Literal
-
-from packaging.version import Version
+from typing import Any
 
 from polaris.utils.types import SlugCompatibleStringType
 
@@ -18,12 +16,3 @@ def sluggify(sluggable: SlugCompatibleStringType):
     Converts a string to a slug-compatible string.
     """
     return sluggable.lower().replace("_", "-")
-
-
-def str_to_version(value: str) -> Version | Literal["dev"]:
-    """
-    Convert a string to a Version object if possible, unless it is 'dev'
-    """
-    if value == "dev":
-        return "dev"
-    return Version(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from polaris.utils.types import HubOwner, License
 
 
 def check_version(artifact):
-    assert po.__version__ == str(artifact.version)
+    assert po.__version__ == artifact.version
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ import datamol as dm
 import numpy as np
 import pytest
 import zarr
+from packaging.version import Version
 
+import polaris as po
 from polaris.benchmark import (
     MultiTaskBenchmarkSpecification,
     SingleTaskBenchmarkSpecification,
@@ -10,6 +12,10 @@ from polaris.benchmark import (
 from polaris.dataset import ColumnAnnotation, Dataset
 from polaris.utils import fs
 from polaris.utils.types import HubOwner, License
+
+
+def check_version(artifact):
+    assert Version(po.__version__) == artifact.version
 
 
 @pytest.fixture(scope="module")
@@ -55,7 +61,7 @@ def test_user_owner():
 
 @pytest.fixture(scope="module")
 def test_dataset(test_data, test_org_owner):
-    return Dataset(
+    dataset = Dataset(
         table=test_data,
         name="test-dataset",
         source="https://www.example.com",
@@ -66,6 +72,8 @@ def test_dataset(test_data, test_org_owner):
         license=License(id="MIT"),
         curation_reference="https://www.example.com",
     )
+    check_version(dataset)
+    return dataset
 
 
 @pytest.fixture(scope="function")
@@ -81,7 +89,7 @@ def zarr_archive(tmp_path):
 def test_single_task_benchmark(test_dataset):
     train_indices = list(range(90))
     test_indices = list(range(90, 100))
-    return SingleTaskBenchmarkSpecification(
+    benchmark = SingleTaskBenchmarkSpecification(
         name="single-task-benchmark",
         dataset=test_dataset,
         metrics=[
@@ -97,13 +105,15 @@ def test_single_task_benchmark(test_dataset):
         target_cols="expt",
         input_cols="smiles",
     )
+    check_version(benchmark)
+    return benchmark
 
 
 @pytest.fixture(scope="function")
 def test_single_task_benchmark_clf(test_dataset):
     train_indices = list(range(90))
     test_indices = list(range(90, 100))
-    return SingleTaskBenchmarkSpecification(
+    benchmark = SingleTaskBenchmarkSpecification(
         name="single-task-benchmark",
         dataset=test_dataset,
         main_metric="accuracy",
@@ -112,13 +122,15 @@ def test_single_task_benchmark_clf(test_dataset):
         target_cols="CLASS_expt",
         input_cols="smiles",
     )
+    check_version(benchmark)
+    return benchmark
 
 
 @pytest.fixture(scope="function")
 def test_single_task_benchmark_multiple_test_sets(test_dataset):
     train_indices = list(range(90))
     test_indices = {"test_1": list(range(90, 95)), "test_2": list(range(95, 100))}
-    return SingleTaskBenchmarkSpecification(
+    benchmark = SingleTaskBenchmarkSpecification(
         name="single-task-benchmark",
         dataset=test_dataset,
         metrics=[
@@ -134,6 +146,8 @@ def test_single_task_benchmark_multiple_test_sets(test_dataset):
         target_cols="expt",
         input_cols="smiles",
     )
+    check_version(benchmark)
+    return benchmark
 
 
 @pytest.fixture(scope="function")
@@ -141,7 +155,7 @@ def test_multi_task_benchmark(test_dataset):
     # For the sake of simplicity, just use a small set of indices
     train_indices = list(range(90))
     test_indices = list(range(90, 100))
-    return MultiTaskBenchmarkSpecification(
+    benchmark = MultiTaskBenchmarkSpecification(
         name="multi-task-benchmark",
         dataset=test_dataset,
         main_metric="mean_absolute_error",
@@ -158,6 +172,8 @@ def test_multi_task_benchmark(test_dataset):
         input_cols="smiles",
         target_types={"expt": "regression"},
     )
+    check_version(benchmark)
+    return benchmark
 
 
 @pytest.fixture(scope="function")
@@ -165,7 +181,7 @@ def test_multi_task_benchmark_clf(test_dataset):
     # For the sake of simplicity, just use a small set of indices
     train_indices = list(range(90))
     test_indices = list(range(90, 100))
-    return MultiTaskBenchmarkSpecification(
+    benchmark = MultiTaskBenchmarkSpecification(
         name="multi-task-benchmark",
         dataset=test_dataset,
         main_metric="accuracy",
@@ -174,3 +190,5 @@ def test_multi_task_benchmark_clf(test_dataset):
         target_cols=["CLASS_expt", "CLASS_calc"],
         input_cols="smiles",
     )
+    check_version(benchmark)
+    return benchmark

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import datamol as dm
 import numpy as np
 import pytest
 import zarr
-from packaging.version import Version
 
 import polaris as po
 from polaris.benchmark import (
@@ -15,7 +14,7 @@ from polaris.utils.types import HubOwner, License
 
 
 def check_version(artifact):
-    assert Version(po.__version__) == artifact.version
+    assert po.__version__ == str(artifact.version)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -2,7 +2,9 @@ import os
 
 import numpy as np
 import pandas as pd
+from packaging.version import Version
 
+import polaris as po
 from polaris.benchmark import MultiTaskBenchmarkSpecification, SingleTaskBenchmarkSpecification
 from polaris.evaluate._metric import Metric
 from polaris.evaluate._results import BenchmarkResults
@@ -36,6 +38,7 @@ def test_result_to_json(tmpdir: str, test_user_owner: HubOwner):
     path = os.path.join(tmpdir, "result.json")
     result.to_json(path)
     BenchmarkResults.from_json(path)
+    assert Version(po.__version__) == result.version
 
 
 def test_metrics_singletask_reg(tmpdir: str, test_single_task_benchmark: SingleTaskBenchmarkSpecification):

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -2,10 +2,12 @@ import os
 
 import numpy as np
 import pandas as pd
-from packaging.version import Version
 
 import polaris as po
-from polaris.benchmark import MultiTaskBenchmarkSpecification, SingleTaskBenchmarkSpecification
+from polaris.benchmark import (
+    MultiTaskBenchmarkSpecification,
+    SingleTaskBenchmarkSpecification,
+)
 from polaris.evaluate._metric import Metric
 from polaris.evaluate._results import BenchmarkResults
 from polaris.utils.types import HubOwner
@@ -38,7 +40,7 @@ def test_result_to_json(tmpdir: str, test_user_owner: HubOwner):
     path = os.path.join(tmpdir, "result.json")
     result.to_json(path)
     BenchmarkResults.from_json(path)
-    assert Version(po.__version__) == result.version
+    assert po.__version__ == result.version
 
 
 def test_metrics_singletask_reg(tmpdir: str, test_single_task_benchmark: SingleTaskBenchmarkSpecification):
@@ -46,7 +48,12 @@ def test_metrics_singletask_reg(tmpdir: str, test_single_task_benchmark: SingleT
     predictions = np.random.random(size=test.inputs.shape[0])
     result = test_single_task_benchmark.evaluate(predictions)
     assert isinstance(result.results, pd.DataFrame)
-    assert set(result.results.columns) == {"Test set", "Target label", "Metric", "Score"}
+    assert set(result.results.columns) == {
+        "Test set",
+        "Target label",
+        "Metric",
+        "Score",
+    }
     for metric in test_single_task_benchmark.metrics:
         assert metric in result.results.Metric.tolist()
 
@@ -78,7 +85,12 @@ def test_metrics_multitask_clf(tmpdir: str, test_multi_task_benchmark_clf: Multi
     }
     result = test_multi_task_benchmark_clf.evaluate(predictions)
     assert isinstance(result.results, pd.DataFrame)
-    assert set(result.results.columns) == {"Test set", "Target label", "Metric", "Score"}
+    assert set(result.results.columns) == {
+        "Test set",
+        "Target label",
+        "Metric",
+        "Score",
+    }
     # check the targets and metrics
     assert result.results.shape[0] == len(test_multi_task_benchmark_clf.target_cols) * len(
         test_multi_task_benchmark_clf.metrics


### PR DESCRIPTION
## Changelogs

- Adds the `version` attribute to the `BaseArtifactModel`. 

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [X] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

If we ever want to change a function that would break backwards compatibility, we now have the opportunity to maintain backwards compatibility by adding conditional logic based on the version. Not saying this should be our preferred approach, but I think it's nevertheless good to have the opportunity. 
