### PR TITLE
Fix a bug in Dataset.cache() and set a default timeout for the PolarisHubClient

### DIFF
--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -366,6 +366,7 @@ class Dataset(BaseArtifactModel):
 
         if self.zarr_root_path is not None:
             self.zarr_root_path = fs.join(self.cache_dir, "data.zarr")
+            self._zarr_root = None
 
         if not self._has_been_cached:
             self._has_been_cached = True

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -115,6 +115,7 @@ class PolarisHubClient(OAuth2Client):
             # httpx.Client
             base_url=settings.api_url,
             verify=verify,
+            timeout=self.settings.default_timeout,
             # Extra
             **kwargs,
         )


### PR DESCRIPTION
## Changelogs

- After calling `Dataset.cache()` the `zarr_root` wasn't reset, because of which it was still using the remote archive. 
- The `default_timeout` parameter for the `PolarisHubClient` can be passed to the `httpx.Client` to properly set it as the default

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---
