### PR TITLE
Updating column adapter logic and usage

### DIFF
--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -37,7 +37,7 @@ class BaseArtifactModel(BaseModel):
         owner: A slug-compatible name for the owner of the dataset.
             If the dataset comes from the Polaris Hub, this is the associated owner (organization or user).
             Together with the name, this is used by the Hub to uniquely identify the benchmark.
-        version: The version of the Polaris library that was used to create the artifact.
+        polaris_version: The version of the Polaris library that was used to create the artifact.
     """
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, arbitrary_types_allowed=True)
@@ -47,14 +47,14 @@ class BaseArtifactModel(BaseModel):
     tags: list[str] = Field(default_factory=list)
     user_attributes: Dict[str, str] = Field(default_factory=dict)
     owner: Optional[HubOwner] = None
-    version: str = po.__version__
+    polaris_version: str = po.__version__
 
     @computed_field
     @property
     def artifact_id(self) -> Optional[str]:
         return f"{self.owner}/{sluggify(self.name)}" if self.owner and self.name else None
 
-    @field_validator("version")
+    @field_validator("polaris_version")
     @classmethod
     def _validate_version(cls, value: str) -> str:
         if value != "dev":

--- a/polaris/dataset/_adapters.py
+++ b/polaris/dataset/_adapters.py
@@ -2,10 +2,8 @@ from enum import Enum
 import datamol as dm
 
 # Map of conversion operations which can be applied to dataset columns
-conversion_map = {
-    'SMILES_TO_MOL': dm.to_mol,
-    'BYTES_TO_MOL': dm.Mol
-}
+conversion_map = {"SMILES_TO_MOL": dm.to_mol, "BYTES_TO_MOL": dm.Mol}
+
 
 class Adapter(Enum):
     """
@@ -17,8 +15,8 @@ class Adapter(Enum):
         BYTES_TO_MOL: Convert a RDKit binary string to a RDKit molecule.
     """
 
-    SMILES_TO_MOL = 'SMILES_TO_MOL'
-    BYTES_TO_MOL = 'BYTES_TO_MOL'
+    SMILES_TO_MOL = "SMILES_TO_MOL"
+    BYTES_TO_MOL = "BYTES_TO_MOL"
 
     def __call__(self, data):
         if isinstance(data, tuple):

--- a/polaris/dataset/_adapters.py
+++ b/polaris/dataset/_adapters.py
@@ -1,10 +1,10 @@
-from enum import Enum
+from enum import Enum, auto, unique
 import datamol as dm
 
 # Map of conversion operations which can be applied to dataset columns
 conversion_map = {"SMILES_TO_MOL": dm.to_mol, "BYTES_TO_MOL": dm.Mol}
 
-
+@unique
 class Adapter(Enum):
     """
     Adapters are predefined callables that change the format of the data.
@@ -15,8 +15,8 @@ class Adapter(Enum):
         BYTES_TO_MOL: Convert a RDKit binary string to a RDKit molecule.
     """
 
-    SMILES_TO_MOL = "SMILES_TO_MOL"
-    BYTES_TO_MOL = "BYTES_TO_MOL"
+    SMILES_TO_MOL = auto()
+    BYTES_TO_MOL = auto()
 
     def __call__(self, data):
         if isinstance(data, tuple):

--- a/polaris/dataset/_adapters.py
+++ b/polaris/dataset/_adapters.py
@@ -4,6 +4,7 @@ import datamol as dm
 # Map of conversion operations which can be applied to dataset columns
 conversion_map = {"SMILES_TO_MOL": dm.to_mol, "BYTES_TO_MOL": dm.Mol}
 
+
 @unique
 class Adapter(Enum):
     """

--- a/polaris/dataset/_adapters.py
+++ b/polaris/dataset/_adapters.py
@@ -1,7 +1,11 @@
 from enum import Enum
-
 import datamol as dm
 
+# Map of conversion operations which can be applied to dataset columns
+conversion_map = {
+    'SMILES_TO_MOL': dm.to_mol,
+    'BYTES_TO_MOL': dm.Mol
+}
 
 class Adapter(Enum):
     """
@@ -13,10 +17,10 @@ class Adapter(Enum):
         BYTES_TO_MOL: Convert a RDKit binary string to a RDKit molecule.
     """
 
-    SMILES_TO_MOL = dm.to_mol
-    BYTES_TO_MOL = dm.Mol
+    SMILES_TO_MOL = 'SMILES_TO_MOL'
+    BYTES_TO_MOL = 'BYTES_TO_MOL'
 
     def __call__(self, data):
         if isinstance(data, tuple):
-            return tuple(self.value(d) for d in data)
-        return self.value(data)
+            return tuple(conversion_map[self.name](d) for d in data)
+        return conversion_map[self.name](data)

--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -154,7 +154,7 @@ class Dataset(BaseArtifactModel):
 
         return m
 
-    @field_validator("default_adapters", mode='before')
+    @field_validator("default_adapters", mode="before")
     def _validate_adapters(cls, value):
         """Validate the adapters"""
         return {k: Adapter[v] if isinstance(v, str) else v for k, v in value.items()}
@@ -274,7 +274,7 @@ class Dataset(BaseArtifactModel):
         adapters = adapters or self.default_adapters
         adapter = adapters.get(col)
 
-        # If not a pointer, return it here. Apply adapter if specified. 
+        # If not a pointer, return it here. Apply adapter if specified.
         value = self.table.loc[row, col]
         if not self.annotations[col].is_pointer:
             if adapter is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from polaris.utils.types import HubOwner, License
 
 
 def check_version(artifact):
-    assert po.__version__ == artifact.version
+    assert po.__version__ == artifact.polaris_version
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -40,7 +40,7 @@ def test_result_to_json(tmpdir: str, test_user_owner: HubOwner):
     path = os.path.join(tmpdir, "result.json")
     result.to_json(path)
     BenchmarkResults.from_json(path)
-    assert po.__version__ == result.version
+    assert po.__version__ == result.polaris_version
 
 
 def test_metrics_singletask_reg(tmpdir: str, test_single_task_benchmark: SingleTaskBenchmarkSpecification):

--- a/tests/test_type_checks.py
+++ b/tests/test_type_checks.py
@@ -74,6 +74,6 @@ def test_license():
 
 def test_version():
     with pytest.raises(ValidationError):
-        BaseArtifactModel(version="invalid")
-    assert BaseArtifactModel().version == po.__version__
-    assert BaseArtifactModel(version="0.1.2")
+        BaseArtifactModel(polaris_version="invalid")
+    assert BaseArtifactModel().polaris_version == po.__version__
+    assert BaseArtifactModel(polaris_version="0.1.2")


### PR DESCRIPTION
## Changelogs

- Updated the attribute name in the BaseArtifactModel which indicates the current Polaris client version from `version` to `polaris_version`
- Fixed column adapter logic by introducing a conversion map and updating how the conversion is applied on dataset retrieval

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
