### PR TITLE
Fix "Connection reset by peer" error when uploading large-ish Zarr datasets

### DIFF
--- a/polaris/hub/polarisfs.py
+++ b/polaris/hub/polarisfs.py
@@ -186,7 +186,7 @@ class PolarisFileSystem(fsspec.AbstractFileSystem):
         pipe_path = self.sep.join([self.base_path, path])
 
         # PUT request to Polaris Hub to put object in path
-        response = self.polaris_client.put(pipe_path, timeout=timeout, content=content)
+        response = self.polaris_client.put(pipe_path, timeout=timeout)
 
         if response.status_code != 307:
             raise PolarisHubError("Could not get signed URL from Polaris Hub.")


### PR DESCRIPTION
## Changelogs

Fixed the "connection reset by peer" error that was occurring for uploading zarr archives ~ 100MB. This was done by removing the passing of `content` when requesting a signed URL from the Hub.

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

