### PR TITLE
Fix: Passing wrong Zarr store that caused metadata consolidation error in upload_dataset() 

### DIFF
--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -605,7 +605,7 @@ class PolarisHubClient(OAuth2Client):
                 # Locally consolidate Zarr archive metadata. Future updates on handling consolidated
                 # metadata based on Zarr developers' recommendations can be tracked at:
                 # https://github.com/zarr-developers/zarr-python/issues/1731
-                zarr.consolidate_metadata(dataset.zarr_root.store)
+                zarr.consolidate_metadata(dataset.zarr_root.store.store)
                 zmetadata_content = dataset.zarr_root.store.store[".zmetadata"]
                 dest.store[".zmetadata"] = zmetadata_content
 


### PR DESCRIPTION
## Changelogs

When consolidating the metadata locally, we were passing different stores which was throwing the error `memoryview: a bytes-like object is required, not 'dict'`. The fix was to append another `.store` when consolidating the metadata.

E.g., `dataset.zarr_root.store`  =>  <zarr.storage.ConsolidatedMetadataStore object at 0x13ddfaba0>
`dataset.zarr_root.store.store`  => <zarr.storage.DirectoryStore object at 0x13d900980>


