### PR TITLE
feat: Copy a Zarr archive to the Hub using copy_store for increased efficient

### DIFF
--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -348,8 +348,15 @@ class Dataset(BaseArtifactModel):
 
         # Copy over Zarr data to the destination
         if self.zarr_root is not None:
-            dest = zarr.DirectoryStore(zarr_archive)
-            zarr.copy_store(source=self.zarr_root.store.store, dest=dest)
+            dest = zarr.open(zarr_archive, "w")
+            zarr.copy_all(source=self.zarr_root, dest=dest)
+
+            # Copy the .zmetadata file
+            # To track discussions on whether this should be done by copy_all()
+            # see https://github.com/zarr-developers/zarr-python/issues/1731
+            zmetadata_content = self.zarr_root.store.store[".zmetadata"]
+            dest.store[".zmetadata"] = zmetadata_content
+
             serialized["zarr_root_path"] = zarr_archive
 
         self.table.to_parquet(table_path)

--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -348,14 +348,15 @@ class Dataset(BaseArtifactModel):
 
         # Copy over Zarr data to the destination
         if self.zarr_root is not None:
-            dest = zarr.open(zarr_archive, "w")
-            zarr.copy_all(source=self.zarr_root, dest=dest)
+            dest = zarr.DirectoryStore(zarr_archive)
+
+            zarr.copy_store(source=self.zarr_root.store.store, dest=dest)
 
             # Copy the .zmetadata file
             # To track discussions on whether this should be done by copy_all()
             # see https://github.com/zarr-developers/zarr-python/issues/1731
             zmetadata_content = self.zarr_root.store.store[".zmetadata"]
-            dest.store[".zmetadata"] = zmetadata_content
+            dest[".zmetadata"] = zmetadata_content
 
             serialized["zarr_root_path"] = zarr_archive
 

--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -349,15 +349,7 @@ class Dataset(BaseArtifactModel):
         # Copy over Zarr data to the destination
         if self.zarr_root is not None:
             dest = zarr.DirectoryStore(zarr_archive)
-
             zarr.copy_store(source=self.zarr_root.store.store, dest=dest)
-
-            # Copy the .zmetadata file
-            # To track discussions on whether this should be done by copy_all()
-            # see https://github.com/zarr-developers/zarr-python/issues/1731
-            zmetadata_content = self.zarr_root.store.store[".zmetadata"]
-            dest[".zmetadata"] = zmetadata_content
-
             serialized["zarr_root_path"] = zarr_archive
 
         self.table.to_parquet(table_path)

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -617,9 +617,6 @@ class PolarisHubClient(OAuth2Client):
                 )
                 dest = zarr.storage.FSStore(url=dataset_json["zarrRootPath"], fs=polaris_fs, mode="w")
 
-                # Locally consolidate Zarr archive metadata. Future updates on handling consolidated
-                # metadata based on Zarr developers' recommendations can be tracked at:
-                # https://github.com/zarr-developers/zarr-python/issues/1731
                 zarr.consolidate_metadata(dataset.zarr_root.store.store)
 
                 logger.info("Copying Zarr archive to the Hub. This may take a while.")

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -33,7 +33,14 @@ from polaris.hub.settings import PolarisHubSettings
 from polaris.utils.constants import DEFAULT_CACHE_DIR
 from polaris.utils.context import tmp_attribute_change
 from polaris.utils.errors import InvalidDatasetError, PolarisHubError, PolarisUnauthorizedError
-from polaris.utils.types import AccessType, HubOwner, IOMode, SupportedLicenseType, TimeoutTypes, ZarrConflictResolution
+from polaris.utils.types import (
+    AccessType,
+    HubOwner,
+    IOMode,
+    SupportedLicenseType,
+    TimeoutTypes,
+    ZarrConflictResolution,
+)
 
 _HTTPX_SSL_ERROR_CODE = "[SSL: CERTIFICATE_VERIFY_FAILED]"
 
@@ -520,7 +527,7 @@ class PolarisHubClient(OAuth2Client):
                 Since datasets can get large, it might be needed to increase the write timeout for larger datasets.
                 See also: https://www.python-httpx.org/advanced/#timeout-configuration
             owner: Which Hub user or organization owns the artifact. Takes precedence over `dataset.owner`.
-            on_upload_conflict: Action for handling existing files in the Zarr archive. Options are 'raise' to throw 
+            on_conflict: Action for handling existing files in the Zarr archive. Options are 'raise' to throw
                 an error, 'replace' to overwrite, or 'skip' to proceed without altering the existing files.
         """
 
@@ -620,8 +627,13 @@ class PolarisHubClient(OAuth2Client):
                 dest.store[".zmetadata"] = zmetadata_content
 
                 logger.info("Copying Zarr archive to the Hub. This may take a while.")
-                zarr.copy_store(source=dataset.zarr_root.store.store, dest=dest.store, log=logger.info, if_exists=on_conflict)
-                
+                zarr.copy_store(
+                    source=dataset.zarr_root.store.store,
+                    dest=dest.store,
+                    log=logger.info,
+                    if_exists=on_conflict,
+                )
+
         logger.success(
             "Your dataset has been successfully uploaded to the Hub. "
             f"View it here: {urljoin(self.settings.hub_url, f'datasets/{dataset.owner}/{dataset.name}')}"

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -532,10 +532,10 @@ class PolarisHubClient(OAuth2Client):
         """
 
         # Check if a dataset license was specified prior to upload
-        # if not dataset.license:
-        #     raise InvalidDatasetError(
-        #         f"\nPlease specify a supported license for this dataset prior to uploading to the Polaris Hub.\nOnly some Creative Commons licenses are supported - {get_args(SupportedLicenseType)}. For more information, see https://creativecommons.org/share-your-work/cclicenses/"
-        #     )
+        if not dataset.license:
+            raise InvalidDatasetError(
+                f"\nPlease specify a supported license for this dataset prior to uploading to the Polaris Hub.\nOnly some Creative Commons licenses are supported - {get_args(SupportedLicenseType)}. For more information, see https://creativecommons.org/share-your-work/cclicenses/"
+            )
 
         # Normalize timeout
         if timeout is None:

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -617,8 +617,8 @@ class PolarisHubClient(OAuth2Client):
                 dest.store[".zmetadata"] = zmetadata_content
 
                 logger.info("Copying Zarr archive to the Hub. This may take a while.")
-                zarr.copy_all(source=dataset.zarr_root, dest=dest, log=logger.info)
-
+                zarr.copy_store(source=dataset.zarr_root.store.store, dest=dest.store, log=logger.info, if_exists='replace')
+                
         logger.success(
             "Your dataset has been successfully uploaded to the Hub. "
             f"View it here: {urljoin(self.settings.hub_url, f'datasets/{dataset.owner}/{dataset.name}')}"

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -610,7 +610,7 @@ class PolarisHubClient(OAuth2Client):
         # Step 3: Upload any associated Zarr archive
         if dataset.zarr_root is not None:
             with tmp_attribute_change(self.settings, "default_timeout", timeout):
-                 # Copy the Zarr archive to the hub
+                # Copy the Zarr archive to the hub
                 dest = self.open_zarr_file(
                     owner=dataset.owner,
                     name=dataset.name,

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -504,7 +504,7 @@ class PolarisHubClient(OAuth2Client):
         access: AccessType = "private",
         timeout: TimeoutTypes = (10, 200),
         owner: Optional[Union[HubOwner, str]] = None,
-        if_exists: ZarrConflictResolution = "raise",
+        if_exists: ZarrConflictResolution = "replace",
     ):
         """Upload the dataset to the Polaris Hub.
 
@@ -610,19 +610,25 @@ class PolarisHubClient(OAuth2Client):
         # Step 3: Upload any associated Zarr archive
         if dataset.zarr_root is not None:
             with tmp_attribute_change(self.settings, "default_timeout", timeout):
-                polaris_fs = PolarisFileSystem(
-                    polaris_client=self,
-                    dataset_owner=dataset.owner,
-                    dataset_name=dataset.name,
+                dest = self.open_zarr_file(
+                    owner=dataset.owner,
+                    name=dataset.name,
+                    path=dataset_json["zarrRootPath"],
+                    mode="w",
+                    as_consolidated=False,
                 )
-                dest = zarr.storage.FSStore(url=dataset_json["zarrRootPath"], fs=polaris_fs, mode="w")
 
+                # Locally consolidate Zarr archive metadata. Future updates on handling consolidated
+                # metadata based on Zarr developers' recommendations can be tracked at:
+                # https://github.com/zarr-developers/zarr-python/issues/1731
                 zarr.consolidate_metadata(dataset.zarr_root.store.store)
-
+                zmetadata_content = dataset.zarr_root.store.store[".zmetadata"]
+                dest.store[".zmetadata"] = zmetadata_content
+            
                 logger.info("Copying Zarr archive to the Hub. This may take a while.")
                 zarr.copy_store(
                     source=dataset.zarr_root.store.store,
-                    dest=dest,
+                    dest=dest.store,
                     log=logger.info,
                     if_exists=if_exists,
                 )

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -624,7 +624,7 @@ class PolarisHubClient(OAuth2Client):
                 zarr.consolidate_metadata(dataset.zarr_root.store.store)
                 zmetadata_content = dataset.zarr_root.store.store[".zmetadata"]
                 dest.store[".zmetadata"] = zmetadata_content
-            
+
                 logger.info("Copying Zarr archive to the Hub. This may take a while.")
                 zarr.copy_store(
                     source=dataset.zarr_root.store.store,

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -610,6 +610,7 @@ class PolarisHubClient(OAuth2Client):
         # Step 3: Upload any associated Zarr archive
         if dataset.zarr_root is not None:
             with tmp_attribute_change(self.settings, "default_timeout", timeout):
+                 # Copy the Zarr archive to the hub
                 dest = self.open_zarr_file(
                     owner=dataset.owner,
                     name=dataset.name,

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -504,7 +504,7 @@ class PolarisHubClient(OAuth2Client):
         access: AccessType = "private",
         timeout: TimeoutTypes = (10, 200),
         owner: Optional[Union[HubOwner, str]] = None,
-        on_conflict: ZarrConflictResolution = "raise",
+        if_exists: ZarrConflictResolution = "raise",
     ):
         """Upload the dataset to the Polaris Hub.
 
@@ -527,7 +527,7 @@ class PolarisHubClient(OAuth2Client):
                 Since datasets can get large, it might be needed to increase the write timeout for larger datasets.
                 See also: https://www.python-httpx.org/advanced/#timeout-configuration
             owner: Which Hub user or organization owns the artifact. Takes precedence over `dataset.owner`.
-            on_conflict: Action for handling existing files in the Zarr archive. Options are 'raise' to throw
+            if_exists: Action for handling existing files in the Zarr archive. Options are 'raise' to throw
                 an error, 'replace' to overwrite, or 'skip' to proceed without altering the existing files.
         """
 
@@ -631,7 +631,7 @@ class PolarisHubClient(OAuth2Client):
                     source=dataset.zarr_root.store.store,
                     dest=dest.store,
                     log=logger.info,
-                    if_exists=on_conflict,
+                    if_exists=if_exists,
                 )
 
         logger.success(

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -99,6 +99,11 @@ SupportedLicenseType: TypeAlias = Literal[
 Supported license types for dataset uploads to Polaris Hub
 """
 
+ZarrConflictResolution: TypeAlias = Literal["raise", "replace", "skip"]
+"""
+Type to specify which action to take when encountering existing files within a Zarr archive.
+"""
+
 
 class HubOwner(BaseModel):
     """An owner of an artifact on the Polaris Hub


### PR DESCRIPTION
## Changelogs

Replaced `copy_all` with `copy_store` when copying a Zarr archive to the Hub. The changes should increase efficiency as `copy_store` does not de-compress and re-compress the data during copying ([see documentation here](https://zarr.readthedocs.io/en/stable/api/convenience.html#zarr.convenience.copy_store)).

Below is the impact it had on profiling:

With `copy_all`:
```Profiling Report
====================================================================================================
Date: 2024-04-04
Time: 17:29:52
Size: 953.67 MB
Repeats: 5
Polaris version: 0.0.2.dev191+g82e7db2
Zarr version: 2.17.1
====================================================================================================
                         Creating the Zarr archive: 0:00:01.344764 ± 0:00:00.151870
         Creating dataset from Source Zarr archive: 0:00:01.509610 ± 0:00:00.201476
                      Uploading dataset to the Hub: 0:08:58.749664 ± 0:00:24.787134
                          Loading dataset from Hub: 0:00:02.294858 ± 0:00:00.129297
                          Caching dataset to local: 0:10:36.877163 ± 0:00:35.494129
                    Iterating over dataset (local): 2:05:54.817060 ± 0:02:11.140053
           Baseline Zarr only upload to Cloudflare: 0:00:30.342002 ± 0:00:01.761582
             Baseline dataset upload to Cloudflare: 0:00:34.035674 ± 0:00:00.615563
       Baseline Zarr only download from Cloudflare: 0:00:44.472856 ± 0:00:21.117384
         Baseline dataset download from Cloudflare: 0:00:33.714192 ± 0:00:01.377525
====================================================================================================
                        Actual / Baseline - Upload: 15.843 ± 0.939
                      Actual / Baseline - Download: 18.926 ± 1.369
```

With `copy_store`:

```Profiling Report
====================================================================================================
Date: 2024-04-09
Time: 06:45:36
Size: 953.67 MB
Repeats: 1
Polaris version: dev
Zarr version: 2.16.1
====================================================================================================
                         Creating the Zarr archive: 0:00:01.407685 ± 0:00:00
         Creating dataset from Source Zarr archive: 0:00:01.874611 ± 0:00:00
                      Uploading dataset to the Hub: 0:28:05.252655 ± 0:00:00
                          Loading dataset from Hub: 0:00:03.237522 ± 0:00:00
                          Caching dataset to local: 0:16:53.128378 ± 0:00:00
           Baseline Zarr only upload to Cloudflare: 0:04:31.668470 ± 0:00:00
             Baseline dataset upload to Cloudflare: 0:04:43.972480 ± 0:00:00
       Baseline Zarr only download from Cloudflare: 0:01:09.703651 ± 0:00:00
         Baseline dataset download from Cloudflare: 0:01:11.038993 ± 0:00:00
====================================================================================================
                        Actual / Baseline - Upload: 5.935 ± 0.000
                      Actual / Baseline - Download: 14.262 ± 0.000
```


**Note:** We did not implement `copy_store` for downloading datasets (only uploading) as it resulted in an increase in caching the dataset locally. See below:

`copy_store` for both upload and download:

```Profiling Report
====================================================================================================
Date: 2024-04-09
Time: 14:02:09
Size: 95.37 MB
Repeats: 1
Polaris version: dev
Zarr version: 2.16.1
====================================================================================================
                         Creating the Zarr archive: 0:00:00.223971 ± 0:00:00
         Creating dataset from Source Zarr archive: 0:00:00.242384 ± 0:00:00
                      Uploading dataset to the Hub: 0:07:06.433739 ± 0:00:00
                          Loading dataset from Hub: 0:00:02.718317 ± 0:00:00
                          Caching dataset to local: 0:04:54.390313 ± 0:00:00
           Baseline Zarr only upload to Cloudflare: 0:00:32.339057 ± 0:00:00
             Baseline dataset upload to Cloudflare: 0:00:33.148623 ± 0:00:00
       Baseline Zarr only download from Cloudflare: 0:00:09.478066 ± 0:00:00
         Baseline dataset download from Cloudflare: 0:00:07.696965 ± 0:00:00
====================================================================================================
                        Actual / Baseline - Upload: 12.864 ± 0.000
                      Actual / Baseline - Download: 38.248 ± 0.000
```
                      
                      
                      
`copy_store` for just upload:


```Profiling Report
====================================================================================================
Date: 2024-04-09
Time: 14:16:02
Size: 95.37 MB
Repeats: 1
Polaris version: dev
Zarr version: 2.16.1
====================================================================================================
                         Creating the Zarr archive: 0:00:00.188619 ± 0:00:00
         Creating dataset from Source Zarr archive: 0:00:00.235259 ± 0:00:00
                      Uploading dataset to the Hub: 0:06:52.969075 ± 0:00:00
                          Loading dataset from Hub: 0:00:02.182547 ± 0:00:00
                          Caching dataset to local: 0:04:19.006523 ± 0:00:00
           Baseline Zarr only upload to Cloudflare: 0:00:32.249822 ± 0:00:00
             Baseline dataset upload to Cloudflare: 0:00:33.095662 ± 0:00:00
       Baseline Zarr only download from Cloudflare: 0:00:07.731580 ± 0:00:00
         Baseline dataset download from Cloudflare: 0:00:07.948864 ± 0:00:00
====================================================================================================
                        Actual / Baseline - Upload: 12.478 ± 0.000
                      Actual / Baseline - Download: 32.584 ± 0.000