### PR TITLE
feat: Update settings for production environment

### DIFF
--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -41,7 +41,10 @@ class PolarisHubSettings(BaseSettings):
     default_timeout: TimeoutTypes = (10, 200)
 
     # Configuration of the pydantic model
-    model_config = SettingsConfigDict(env_prefix="POLARIS_")
+    model_config = SettingsConfigDict(
+        env_file='.env',
+        env_prefix="POLARIS_"
+    )
 
     @field_validator("api_url", mode="before")
     def validate_api_url(cls, v, info: ValidationInfo):

--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -41,10 +41,7 @@ class PolarisHubSettings(BaseSettings):
     default_timeout: TimeoutTypes = (10, 200)
 
     # Configuration of the pydantic model
-    model_config = SettingsConfigDict(
-        env_file='.env',
-        env_prefix="POLARIS_"
-    )
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="POLARIS_")
 
     @field_validator("api_url", mode="before")
     def validate_api_url(cls, v, info: ValidationInfo):

--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -30,12 +30,12 @@ class PolarisHubSettings(BaseSettings):
 
     hub_url: HttpUrlString = "https://polarishub.io/"
     api_url: Optional[HttpUrlString] = None
-    authorize_url: HttpUrlString = "https://pure-whippet-77.clerk.accounts.dev/oauth/authorize"
+    authorize_url: HttpUrlString = "https://clerk.polarishub.io/oauth/authorize"
     callback_url: HttpUrlString = "https://polarishub.io/oauth2/callback"
-    token_fetch_url: HttpUrlString = "https://pure-whippet-77.clerk.accounts.dev/oauth/token"
-    user_info_url: HttpUrlString = "https://pure-whippet-77.clerk.accounts.dev/oauth/userinfo"
+    token_fetch_url: HttpUrlString = "https://clerk.polarishub.io/oauth/token"
+    user_info_url: HttpUrlString = "https://clerk.polarishub.io/oauth/userinfo"
     scopes: str = "profile email"
-    client_id: str = "QJg8zadGwjnr6nbN"
+    client_id: str = "agQP2xVM6JqMHvGc"
     ca_bundle: Optional[Union[str, bool]] = None
 
     default_timeout: TimeoutTypes = (10, 200)


### PR DESCRIPTION
## Changelogs

This PR updates the default settings for the client to use the new Clerk production environment.

For local dev, the client now supports using a `.env` file to point to Clerk's development environment. Use these values:
```.env
POLARIS_HUB_URL="http://localhost:3000/"
POLARIS_AUTHORIZE_URL="https://pure-whippet-77.clerk.accounts.dev/oauth/authorize"
POLARIS_TOKEN_FETCH_URL="https://pure-whippet-77.clerk.accounts.dev/oauth/token"
POLARIS_USER_INFO_URL="https://pure-whippet-77.clerk.accounts.dev/oauth/userinfo"
POLARIS_CLIENT_ID="QJg8zadGwjnr6nbN"
```

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
