### PR TITLE
fix: Client ignoring default .env file

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -28,7 +28,7 @@ jobs:
           pip install ruff
 
       - name: Lint
-        run: ruff .
+        run: ruff check .
 
       - name: Format
         run: ruff format . --check

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -1,5 +1,4 @@
 import json
-import os
 from hashlib import md5
 from typing import Any, Callable, Optional, Union
 
@@ -488,7 +487,6 @@ class BenchmarkSpecification(BaseArtifactModel):
 
     def upload_to_hub(
         self,
-        env_file: Optional[Union[str, os.PathLike]] = None,
         settings: Optional[PolarisHubSettings] = None,
         cache_auth_token: bool = True,
         access: Optional[AccessType] = "private",
@@ -502,7 +500,6 @@ class BenchmarkSpecification(BaseArtifactModel):
         from polaris.hub.client import PolarisHubClient
 
         with PolarisHubClient(
-            env_file=env_file,
             settings=settings,
             cache_auth_token=cache_auth_token,
             **kwargs,

--- a/polaris/cli.py
+++ b/polaris/cli.py
@@ -1,8 +1,9 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
 from polaris.hub.client import PolarisHubClient
+from polaris.hub.settings import PolarisHubSettings
 
 app = typer.Typer(
     add_completion=False,
@@ -13,8 +14,8 @@ app = typer.Typer(
 @app.command("login")
 def login(
     client_env_file: Annotated[
-        Optional[str], typer.Option(help="Environment file to overwrite the default environment variables")
-    ] = None,
+        str, typer.Option(help="Environment file to overwrite the default environment variables")
+    ] = ".env",
     auto_open_browser: Annotated[
         bool, typer.Option(help="Whether to automatically open the link in a browser to retrieve the token")
     ] = True,
@@ -26,7 +27,7 @@ def login(
 
     This CLI will use the OAuth2 protocol to gain token-based access to the Polaris Hub API.
     """
-    with PolarisHubClient(env_file=client_env_file) as client:
+    with PolarisHubClient(settings=PolarisHubSettings(_env_file=client_env_file)) as client:
         client.login(auto_open_browser=auto_open_browser, overwrite=overwrite)
 
 

--- a/polaris/evaluate/_results.py
+++ b/polaris/evaluate/_results.py
@@ -191,9 +191,7 @@ class BenchmarkResults(BaseArtifactModel):
         """
         from polaris.hub.client import PolarisHubClient
 
-        with PolarisHubClient(
-            env_file=env_file, settings=settings, cache_auth_token=cache_auth_token, **kwargs
-        ) as client:
+        with PolarisHubClient(settings=settings, cache_auth_token=cache_auth_token, **kwargs) as client:
             return client.upload_results(self, access=access, owner=owner)
 
     def _repr_dict_(self) -> dict:

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -107,14 +107,14 @@ class PolarisHubClient(OAuth2Client):
 
         super().__init__(
             # OAuth2Client
-            client_id=settings.client_id,
-            redirect_uri=settings.callback_url,
-            scope=settings.scopes,
+            client_id=self.settings.client_id,
+            redirect_uri=self.settings.callback_url,
+            scope=self.settings.scopes,
             token=token,
             token_endpoint=self.settings.token_fetch_url,
             code_challenge_method="S256",
             # httpx.Client
-            base_url=settings.api_url,
+            base_url=self.settings.api_url,
             verify=verify,
             timeout=self.settings.default_timeout,
             # Extra

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -1,5 +1,4 @@
 import json
-import os
 import ssl
 import webbrowser
 from hashlib import md5
@@ -79,24 +78,19 @@ class PolarisHubClient(OAuth2Client):
 
     def __init__(
         self,
-        env_file: Optional[Union[str, os.PathLike]] = None,
         settings: Optional[PolarisHubSettings] = None,
         cache_auth_token: bool = True,
         **kwargs: dict,
     ):
         """
         Args:
-            env_file: Path to a `.env` file containing the settings, used to initialize
-                a `PolarisHubSettings` instance. If not provided, the default settings are used.
-            settings: A `PolarisHubSettings` instance. If provided, takes precedence over `env_file`.
+            settings: A `PolarisHubSettings` instance.
             cache_auth_token: Whether to cache the auth token to a file.
             **kwargs: Additional keyword arguments passed to the authlib `OAuth2Client` constructor.
         """
         self._user_info = None
 
-        if settings is None:
-            settings = PolarisHubSettings(_env_file=env_file)  # type: ignore
-        self.settings = settings
+        self.settings = PolarisHubSettings() if settings is None else settings
 
         # We cache the auth token by default, but allow the user to disable this.
         self.cache_auth_token = cache_auth_token


### PR DESCRIPTION
## Changelogs

This PR removes the optional .env parameter used in certain places, when instantiating a Hub client class. This was overriding the default value set in the `PolarisHubSettings` class. 

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
