### PR TITLE
Use evaluation logic directly in hub, no need for wrapper

### DIFF
--- a/polaris/competition/_competition.py
+++ b/polaris/competition/_competition.py
@@ -5,8 +5,6 @@ from typing import Optional, Union
 
 from pydantic import field_serializer
 from polaris.benchmark import BenchmarkSpecification
-from polaris.evaluate import BenchmarkResults
-from polaris.evaluate.utils import evaluate_benchmark
 from polaris.hub.settings import PolarisHubSettings
 from polaris.utils.types import AccessType, HubOwner, PredictionsType, TimeoutTypes, ZarrConflictResolution
 

--- a/polaris/competition/_competition.py
+++ b/polaris/competition/_competition.py
@@ -51,27 +51,6 @@ class CompetitionSpecification(BenchmarkSpecification):
         ) as client:
             client.evaluate_competition(self, y_pred=y_pred)
 
-    def _hub_evaluate(self, y_pred: PredictionsType, y_true: PredictionsType):
-        """Executes the evaluation logic for a competition, given a set of predictions.
-        Called only by Polaris Hub to evaluate competitions after labels are
-        downloaded from R2 on the hub. Evalutaion logic is the same as for regular benchmarks.
-
-        Args:
-            y_pred: The predictions for the test set, as NumPy arrays.
-                If there are multiple targets, the predictions should be wrapped in a
-                dictionary with the target labels as keys.
-
-            test: The test set. If there are multiple targets, the target columns should
-                be wrapped in a dictionary with the target labels as keys.
-
-        Returns:
-            A `BenchmarkResults` object containing the evaluation results.
-        """
-        scores = evaluate_benchmark(y_pred, y_true, self.target_cols, self.metrics)
-        return BenchmarkResults(results=scores,
-                                benchmark_name=self.name,
-                                benchmark_owner=self.owner)
-
     def upload_to_hub(
         self,
         env_file: Optional[Union[str, os.PathLike]] = None,

--- a/polaris/evaluate/__init__.py
+++ b/polaris/evaluate/__init__.py
@@ -1,4 +1,9 @@
 from polaris.evaluate._metric import Metric, MetricInfo
 from polaris.evaluate._results import BenchmarkResults, ResultsType
+from polaris.evaluate.utils import evaluate_benchmark
 
-__all__ = ["Metric", "MetricInfo", "BenchmarkResults", "ResultsType"]
+__all__ = ["Metric",
+           "MetricInfo",
+           "BenchmarkResults",
+           "ResultsType",
+           "evaluate_benchmark"]

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -874,6 +874,6 @@ class PolarisHubClient(OAuth2Client):
                 "competition": competition.artifact_id,
                 "predictions": y_pred
             })
-        return BenchmarkResults(results=response["scores"],
+        return BenchmarkResults(results=pd.read_json(response["scores"]),
                                 benchmark_name=competition.name,
                                 benchmark_owner=competition.owner)

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -856,7 +856,8 @@ class PolarisHubClient(OAuth2Client):
         competition: CompetitionSpecification,
         y_pred: PredictionsType
     ) -> BenchmarkResults:
-        """Evaluate the predictions for a competition on the Polaris Hub.
+        """Evaluate the predictions for a competition on the Polaris Hub. Target labels are fetched
+        by Polaris Hub and used only internally.
 
         Args:
             competition: The competition to evaluate the predictions for.
@@ -866,10 +867,13 @@ class PolarisHubClient(OAuth2Client):
         Returns:
              A `BenchmarkResults` object.
         """
-        return self._base_request_to_hub(
+        response = self._base_request_to_hub(
             url=f"/v2/competition/evaluate",
             method="PUT",
             json={
                 "competition": competition.artifact_id,
                 "predictions": y_pred
             })
+        return BenchmarkResults(results=response["scores"],
+                                benchmark_name=competition.name,
+                                benchmark_owner=competition.owner)

--- a/tests/test_competition.py
+++ b/tests/test_competition.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 
 from polaris.competition import CompetitionSpecification
@@ -11,17 +10,3 @@ def test_competition_from_json(test_competition, tmpdir):
     path = test_competition.to_json(str(tmpdir))
     new_competition = CompetitionSpecification.from_json(path)
     assert new_competition == test_competition
-
-def test_competition_evaluation(test_competition):
-    """Test whether we can successfully evaluate a competition."""
-    competition = test_competition
-    result = competition._hub_evaluate(predictions, test)
-    assert isinstance(result.results, pd.DataFrame)
-    assert set(result.results.columns) == {
-        "Test set",
-        "Target label",
-        "Metric",
-        "Score",
-    }
-    for metric in competition.metrics:
-        assert metric in result.results.Metric.tolist()


### PR DESCRIPTION
## Changelogs

This PR removes the wrapper around the evaluation logic for use by the hub. Instead we can just call `evaluate_benchmark` directly from there. This requires testing in the context of working competitions, which we will do next. This requires the accompanying PR in the hub, https://github.com/polaris-hub/polaris-hub/pull/338

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

