### PR TITLE
Test that all rows of a competition test set will have at least a value

### DIFF
--- a/polaris/utils/errors.py
+++ b/polaris/utils/errors.py
@@ -5,6 +5,8 @@ class InvalidDatasetError(ValueError):
 class InvalidBenchmarkError(ValueError):
     pass
 
+class InvalidCompetitionError(ValueError):
+    pass
 
 class InvalidResultError(ValueError):
     pass

--- a/tests/test_competition.py
+++ b/tests/test_competition.py
@@ -1,8 +1,13 @@
 import numpy as np
 import pandas as pd
-from polaris.evaluate.utils import evaluate_benchmark
+import pytest
 
+from pydantic import ValidationError
+from polaris.evaluate.utils import evaluate_benchmark
 from polaris.competition import CompetitionSpecification
+from polaris.dataset import Dataset
+from polaris.utils.types import HubOwner
+from polaris.utils.errors import InvalidCompetitionError
 
 def test_competition_from_json(test_competition, tmpdir):
     """Test whether we can successfully save and load a competition from JSON."""
@@ -54,3 +59,61 @@ def test_single_col_competition_evaluation(test_competition):
         "Metric",
         "Score",
     }
+
+def test_invalid_competition_creation():
+    data = {"col a": [1, 2, None],
+            "col b": [4, None, 6],
+            "col c": [7, 8, None]}
+
+    df = pd.DataFrame(data, index=range(3))
+    dataset = Dataset(
+        table=df,
+        name="test-dataset"
+    )
+
+    # Check that creating a competition where there is at least one value per test row works
+    CompetitionSpecification(
+        name="test-competition",
+        owner=HubOwner(organizationId="test-org", slug="test-org"),
+        dataset=dataset,
+        metrics=["mean_absolute_error", "mean_squared_error"],
+        split=([0, 1], [2]),
+        target_cols=["col b"],
+        input_cols=["col a", "col c"]
+    )
+
+    CompetitionSpecification(
+        name="test-competition",
+        owner=HubOwner(organizationId="test-org", slug="test-org"),
+        dataset=dataset,
+        metrics=["mean_absolute_error", "mean_squared_error"],
+        split=([0, 1], [2]),
+        target_cols=["col a", "col b"],
+        input_cols=["col c"]
+    )
+
+    with pytest.raises(ValidationError) as ex_info:
+        CompetitionSpecification(
+            name="test-competition",
+            owner=HubOwner(organizationId="test-org", slug="test-org"),
+            dataset=dataset,
+            metrics=["mean_absolute_error", "mean_squared_error"],
+            split=([0, 1], [2]),
+            target_cols=["col a"],
+            input_cols=["col b", "col c"]
+        )
+
+    assert ex_info.match("All rows of the test set must have at least one value")
+
+    with pytest.raises(ValidationError) as ex_info_2:
+        CompetitionSpecification(
+            name="test-competition",
+            owner=HubOwner(organizationId="test-org", slug="test-org"),
+            dataset=dataset,
+            metrics=["mean_absolute_error", "mean_squared_error"],
+            split=([0, 1], [2]),
+            target_cols=["col a", "col c"],
+            input_cols=["col b"]
+        )
+
+    assert ex_info_2.match("All rows of the test set must have at least one value")


### PR DESCRIPTION
## Changelogs

- adds some validation on competition creation to check that all test rows will have at least one value in a target column

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [-] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

This is a small improvement discussed with Andrew before his vacation. We want to make sure that you can't create a competition where there is missing test data.
