### PR TITLE
Remove polyfill

### DIFF
--- a/0.1.0/404.html
+++ b/0.1.0/404.html
@@ -1041,8 +1041,6 @@
     
       <script src="/polaris-hub/polaris/0.1.0/assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/api/base.html
+++ b/0.1.0/api/base.html
@@ -1487,8 +1487,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/api/benchmark.html
+++ b/0.1.0/api/benchmark.html
@@ -1899,8 +1899,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/api/dataset.html
+++ b/0.1.0/api/dataset.html
@@ -2120,8 +2120,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/api/evaluation.html
+++ b/0.1.0/api/evaluation.html
@@ -1669,8 +1669,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/api/hub.client.html
+++ b/0.1.0/api/hub.client.html
@@ -2428,8 +2428,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/api/subset.html
+++ b/0.1.0/api/subset.html
@@ -1301,8 +1301,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/api/utils.types.html
+++ b/0.1.0/api/utils.types.html
@@ -1774,8 +1774,6 @@ Else it is required to manually specify this.</p>
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/community/community.html
+++ b/0.1.0/community/community.html
@@ -1132,8 +1132,6 @@
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/index.html
+++ b/0.1.0/index.html
@@ -1262,8 +1262,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/quickstart.html
+++ b/0.1.0/quickstart.html
@@ -1295,8 +1295,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/tutorials/basics.html
+++ b/0.1.0/tutorials/basics.html
@@ -2320,8 +2320,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/tutorials/custom_dataset_benchmark.html
+++ b/0.1.0/tutorials/custom_dataset_benchmark.html
@@ -2608,8 +2608,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/tutorials/data_curation.html
+++ b/0.1.0/tutorials/data_curation.html
@@ -2275,8 +2275,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.1.0/tutorials/dataset_zarr.html
+++ b/0.1.0/tutorials/dataset_zarr.html
@@ -2557,8 +2557,6 @@ zarr_path = dataset.to_zarr(savedir, array_mode="single")</div>
     
       <script src="../assets/javascripts/bundle.aecac24b.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/404.html
+++ b/0.2.0/404.html
@@ -1041,8 +1041,6 @@
     
       <script src="/polaris-hub/polaris/0.2.0/assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/api/base.html
+++ b/0.2.0/api/base.html
@@ -1499,8 +1499,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/api/benchmark.html
+++ b/0.2.0/api/benchmark.html
@@ -1931,8 +1931,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/api/dataset.html
+++ b/0.2.0/api/dataset.html
@@ -2156,8 +2156,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/api/evaluation.html
+++ b/0.2.0/api/evaluation.html
@@ -1689,8 +1689,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/api/hub.client.html
+++ b/0.2.0/api/hub.client.html
@@ -2476,8 +2476,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/api/subset.html
+++ b/0.2.0/api/subset.html
@@ -1305,8 +1305,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/api/utils.types.html
+++ b/0.2.0/api/utils.types.html
@@ -1863,8 +1863,6 @@ Else it is required to manually specify this.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/community/community.html
+++ b/0.2.0/community/community.html
@@ -1132,8 +1132,6 @@
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/index.html
+++ b/0.2.0/index.html
@@ -1274,8 +1274,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/quickstart.html
+++ b/0.2.0/quickstart.html
@@ -1311,8 +1311,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/tutorials/basics.html
+++ b/0.2.0/tutorials/basics.html
@@ -2362,8 +2362,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/tutorials/custom_dataset_benchmark.html
+++ b/0.2.0/tutorials/custom_dataset_benchmark.html
@@ -2625,8 +2625,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/tutorials/data_curation.html
+++ b/0.2.0/tutorials/data_curation.html
@@ -2283,8 +2283,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.0/tutorials/dataset_zarr.html
+++ b/0.2.0/tutorials/dataset_zarr.html
@@ -2571,8 +2571,6 @@ zarr_path = dataset.to_zarr(savedir, array_mode="single")</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/404.html
+++ b/0.2.1/404.html
@@ -1041,8 +1041,6 @@
     
       <script src="/polaris-hub/polaris/0.2.1/assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/api/base.html
+++ b/0.2.1/api/base.html
@@ -1499,8 +1499,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/api/benchmark.html
+++ b/0.2.1/api/benchmark.html
@@ -1931,8 +1931,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/api/dataset.html
+++ b/0.2.1/api/dataset.html
@@ -2156,8 +2156,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/api/evaluation.html
+++ b/0.2.1/api/evaluation.html
@@ -1689,8 +1689,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/api/hub.client.html
+++ b/0.2.1/api/hub.client.html
@@ -2476,8 +2476,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/api/subset.html
+++ b/0.2.1/api/subset.html
@@ -1305,8 +1305,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/api/utils.types.html
+++ b/0.2.1/api/utils.types.html
@@ -1863,8 +1863,6 @@ Else it is required to manually specify this.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/community/community.html
+++ b/0.2.1/community/community.html
@@ -1132,8 +1132,6 @@
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/index.html
+++ b/0.2.1/index.html
@@ -1274,8 +1274,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/quickstart.html
+++ b/0.2.1/quickstart.html
@@ -1311,8 +1311,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/tutorials/basics.html
+++ b/0.2.1/tutorials/basics.html
@@ -2362,8 +2362,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/tutorials/custom_dataset_benchmark.html
+++ b/0.2.1/tutorials/custom_dataset_benchmark.html
@@ -2625,8 +2625,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/tutorials/data_curation.html
+++ b/0.2.1/tutorials/data_curation.html
@@ -2283,8 +2283,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.1/tutorials/dataset_zarr.html
+++ b/0.2.1/tutorials/dataset_zarr.html
@@ -2571,8 +2571,6 @@ zarr_path = dataset.to_zarr(savedir, array_mode="single")</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/404.html
+++ b/0.2.2/404.html
@@ -1052,8 +1052,6 @@
     
       <script src="/polaris-hub/polaris/0.2.2/assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/base.html
+++ b/0.2.2/api/base.html
@@ -1508,8 +1508,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/benchmark.html
+++ b/0.2.2/api/benchmark.html
@@ -1941,8 +1941,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/dataset.html
+++ b/0.2.2/api/dataset.html
@@ -2166,8 +2166,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/evaluation.html
+++ b/0.2.2/api/evaluation.html
@@ -1699,8 +1699,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/hub.client.html
+++ b/0.2.2/api/hub.client.html
@@ -2541,8 +2541,6 @@ Optional if and only if the <code>benchmark.owner</code> attribute is set.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/load.html
+++ b/0.2.2/api/load.html
@@ -1313,8 +1313,6 @@ supported by the Hub.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/subset.html
+++ b/0.2.2/api/subset.html
@@ -1314,8 +1314,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/api/utils.types.html
+++ b/0.2.2/api/utils.types.html
@@ -1872,8 +1872,6 @@ Else it is required to manually specify this.</p>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/community/community.html
+++ b/0.2.2/community/community.html
@@ -1143,8 +1143,6 @@
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/index.html
+++ b/0.2.2/index.html
@@ -1285,8 +1285,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/quickstart.html
+++ b/0.2.2/quickstart.html
@@ -1335,8 +1335,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/tutorials/basics.html
+++ b/0.2.2/tutorials/basics.html
@@ -2346,8 +2346,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/tutorials/custom_dataset_benchmark.html
+++ b/0.2.2/tutorials/custom_dataset_benchmark.html
@@ -2636,8 +2636,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/tutorials/data_curation.html
+++ b/0.2.2/tutorials/data_curation.html
@@ -2294,8 +2294,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.2/tutorials/dataset_zarr.html
+++ b/0.2.2/tutorials/dataset_zarr.html
@@ -2582,8 +2582,6 @@ zarr_path = dataset.to_zarr(savedir, array_mode="single")</div>
     
       <script src="../assets/javascripts/bundle.6c14ae12.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/404.html
+++ b/0.2.3/404.html
@@ -1073,8 +1073,6 @@
     
       <script src="/polaris-hub/polaris/0.2.3/assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/base.html
+++ b/0.2.3/api/base.html
@@ -1529,8 +1529,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/benchmark.html
+++ b/0.2.3/api/benchmark.html
@@ -2304,8 +2304,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/dataset.html
+++ b/0.2.3/api/dataset.html
@@ -2377,8 +2377,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/evaluation.html
+++ b/0.2.3/api/evaluation.html
@@ -1720,8 +1720,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/hub.client.html
+++ b/0.2.3/api/hub.client.html
@@ -2562,8 +2562,6 @@ Optional if and only if the <code>benchmark.owner</code> attribute is set.</p>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/load.html
+++ b/0.2.3/api/load.html
@@ -1334,8 +1334,6 @@ supported by the Hub.</p>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/subset.html
+++ b/0.2.3/api/subset.html
@@ -1335,8 +1335,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/api/utils.types.html
+++ b/0.2.3/api/utils.types.html
@@ -2009,8 +2009,6 @@ Else it is required to manually specify this.</p>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/community/community.html
+++ b/0.2.3/community/community.html
@@ -1164,8 +1164,6 @@
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/index.html
+++ b/0.2.3/index.html
@@ -1306,8 +1306,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/quickstart.html
+++ b/0.2.3/quickstart.html
@@ -1371,8 +1371,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/tutorials/basics.html
+++ b/0.2.3/tutorials/basics.html
@@ -2367,8 +2367,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/tutorials/custom_dataset_benchmark.html
+++ b/0.2.3/tutorials/custom_dataset_benchmark.html
@@ -2657,8 +2657,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/tutorials/data_curation.html
+++ b/0.2.3/tutorials/data_curation.html
@@ -2315,8 +2315,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.3/tutorials/dataset_zarr.html
+++ b/0.2.3/tutorials/dataset_zarr.html
@@ -2603,8 +2603,6 @@ zarr_path = dataset.to_zarr(savedir, array_mode="single")</div>
     
       <script src="../assets/javascripts/bundle.cd18aaf1.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/404.html
+++ b/0.2.4/404.html
@@ -1248,8 +1248,6 @@
     
       <script src="/polaris-hub/polaris/0.2.4/assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/adapters.html
+++ b/0.2.4/api/adapters.html
@@ -1575,8 +1575,6 @@ Adapters are serializable and can thus be saved alongside datasets.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/base.html
+++ b/0.2.4/api/base.html
@@ -1721,8 +1721,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/benchmark.html
+++ b/0.2.4/api/benchmark.html
@@ -2466,8 +2466,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/converters.html
+++ b/0.2.4/api/converters.html
@@ -1871,8 +1871,6 @@ to a single column and each array contains the values for all datapoints in that
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/dataset.html
+++ b/0.2.4/api/dataset.html
@@ -2365,8 +2365,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/evaluation.html
+++ b/0.2.4/api/evaluation.html
@@ -1905,8 +1905,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/factory.html
+++ b/0.2.4/api/factory.html
@@ -2090,8 +2090,6 @@ For creating more complicated datasets, please use the <code>DatasetFactory</cod
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/hub.client.html
+++ b/0.2.4/api/hub.client.html
@@ -2863,8 +2863,6 @@ Optional if and only if the <code>benchmark.owner</code> attribute is set.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/hub.polarisfs.html
+++ b/0.2.4/api/hub.polarisfs.html
@@ -2079,8 +2079,6 @@ as a placeholder that aligns with the Zarr interface's expectations.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/load.html
+++ b/0.2.4/api/load.html
@@ -1521,8 +1521,6 @@ and can be part of <em>one or multiple benchmarks</em>.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/subset.html
+++ b/0.2.4/api/subset.html
@@ -1543,8 +1543,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/api/utils.types.html
+++ b/0.2.4/api/utils.types.html
@@ -2225,8 +2225,6 @@ Else it is required to manually specify this.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/community/community.html
+++ b/0.2.4/community/community.html
@@ -1346,8 +1346,6 @@
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/index.html
+++ b/0.2.4/index.html
@@ -1491,8 +1491,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/quickstart.html
+++ b/0.2.4/quickstart.html
@@ -1556,8 +1556,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/tutorials/basics.html
+++ b/0.2.4/tutorials/basics.html
@@ -3007,8 +3007,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/tutorials/custom_dataset_benchmark.html
+++ b/0.2.4/tutorials/custom_dataset_benchmark.html
@@ -2875,8 +2875,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/tutorials/data_curation.html
+++ b/0.2.4/tutorials/data_curation.html
@@ -2535,8 +2535,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/tutorials/dataset_factory.html
+++ b/0.2.4/tutorials/dataset_factory.html
@@ -2718,8 +2718,6 @@ dataset = factory.build()</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.4/tutorials/dataset_zarr.html
+++ b/0.2.4/tutorials/dataset_zarr.html
@@ -2803,8 +2803,6 @@ fs.ls(SAVE_DIR)</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/404.html
+++ b/0.2.5/404.html
@@ -1248,8 +1248,6 @@
     
       <script src="/polaris-hub/polaris/0.2.5/assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/adapters.html
+++ b/0.2.5/api/adapters.html
@@ -1575,8 +1575,6 @@ Adapters are serializable and can thus be saved alongside datasets.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/base.html
+++ b/0.2.5/api/base.html
@@ -1721,8 +1721,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/benchmark.html
+++ b/0.2.5/api/benchmark.html
@@ -2466,8 +2466,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/converters.html
+++ b/0.2.5/api/converters.html
@@ -1871,8 +1871,6 @@ to a single column and each array contains the values for all datapoints in that
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/dataset.html
+++ b/0.2.5/api/dataset.html
@@ -2365,8 +2365,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/evaluation.html
+++ b/0.2.5/api/evaluation.html
@@ -1905,8 +1905,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/factory.html
+++ b/0.2.5/api/factory.html
@@ -2090,8 +2090,6 @@ For creating more complicated datasets, please use the <code>DatasetFactory</cod
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/hub.client.html
+++ b/0.2.5/api/hub.client.html
@@ -2891,8 +2891,6 @@ Optional if and only if the <code>benchmark.owner</code> attribute is set.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/hub.polarisfs.html
+++ b/0.2.5/api/hub.polarisfs.html
@@ -2079,8 +2079,6 @@ as a placeholder that aligns with the Zarr interface's expectations.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/load.html
+++ b/0.2.5/api/load.html
@@ -1521,8 +1521,6 @@ and can be part of <em>one or multiple benchmarks</em>.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/subset.html
+++ b/0.2.5/api/subset.html
@@ -1543,8 +1543,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/api/utils.types.html
+++ b/0.2.5/api/utils.types.html
@@ -2225,8 +2225,6 @@ Else it is required to manually specify this.</p>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/community/community.html
+++ b/0.2.5/community/community.html
@@ -1346,8 +1346,6 @@
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/index.html
+++ b/0.2.5/index.html
@@ -1491,8 +1491,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/quickstart.html
+++ b/0.2.5/quickstart.html
@@ -1556,8 +1556,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/tutorials/basics.html
+++ b/0.2.5/tutorials/basics.html
@@ -3007,8 +3007,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/tutorials/custom_dataset_benchmark.html
+++ b/0.2.5/tutorials/custom_dataset_benchmark.html
@@ -2875,8 +2875,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/tutorials/data_curation.html
+++ b/0.2.5/tutorials/data_curation.html
@@ -2535,8 +2535,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/tutorials/dataset_factory.html
+++ b/0.2.5/tutorials/dataset_factory.html
@@ -2718,8 +2718,6 @@ dataset = factory.build()</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.5/tutorials/dataset_zarr.html
+++ b/0.2.5/tutorials/dataset_zarr.html
@@ -2803,8 +2803,6 @@ fs.ls(SAVE_DIR)</div>
     
       <script src="../assets/javascripts/bundle.bd41221c.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/404.html
+++ b/0.2.6/404.html
@@ -1248,8 +1248,6 @@
     
       <script src="/polaris-hub/polaris/0.2.6/assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/adapters.html
+++ b/0.2.6/api/adapters.html
@@ -1575,8 +1575,6 @@ Adapters are serializable and can thus be saved alongside datasets.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/base.html
+++ b/0.2.6/api/base.html
@@ -1721,8 +1721,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/benchmark.html
+++ b/0.2.6/api/benchmark.html
@@ -2466,8 +2466,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/converters.html
+++ b/0.2.6/api/converters.html
@@ -1857,8 +1857,6 @@ to a single column and each array contains the values for all datapoints in that
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/dataset.html
+++ b/0.2.6/api/dataset.html
@@ -2458,8 +2458,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/evaluation.html
+++ b/0.2.6/api/evaluation.html
@@ -1905,8 +1905,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/factory.html
+++ b/0.2.6/api/factory.html
@@ -2090,8 +2090,6 @@ For creating more complicated datasets, please use the <code>DatasetFactory</cod
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/hub.client.html
+++ b/0.2.6/api/hub.client.html
@@ -2902,8 +2902,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/hub.polarisfs.html
+++ b/0.2.6/api/hub.polarisfs.html
@@ -2176,8 +2176,6 @@ as a placeholder that aligns with the Zarr interface's expectations.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/load.html
+++ b/0.2.6/api/load.html
@@ -1521,8 +1521,6 @@ and can be part of <em>one or multiple benchmarks</em>.</p>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/subset.html
+++ b/0.2.6/api/subset.html
@@ -1543,8 +1543,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/api/utils.types.html
+++ b/0.2.6/api/utils.types.html
@@ -2152,8 +2152,6 @@ The externalId and type are added to be consistent with the model returned by th
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/community/community.html
+++ b/0.2.6/community/community.html
@@ -1312,8 +1312,6 @@
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/index.html
+++ b/0.2.6/index.html
@@ -1491,8 +1491,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/quickstart.html
+++ b/0.2.6/quickstart.html
@@ -1556,8 +1556,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/tutorials/basics.html
+++ b/0.2.6/tutorials/basics.html
@@ -3007,8 +3007,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/tutorials/custom_dataset_benchmark.html
+++ b/0.2.6/tutorials/custom_dataset_benchmark.html
@@ -2875,8 +2875,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/tutorials/data_curation.html
+++ b/0.2.6/tutorials/data_curation.html
@@ -2535,8 +2535,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/tutorials/dataset_factory.html
+++ b/0.2.6/tutorials/dataset_factory.html
@@ -2710,8 +2710,6 @@ dataset = factory.build()</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.2.6/tutorials/dataset_zarr.html
+++ b/0.2.6/tutorials/dataset_zarr.html
@@ -2800,8 +2800,6 @@ fs.ls(SAVE_DIR)</div>
     
       <script src="../assets/javascripts/bundle.1e8ae164.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/404.html
+++ b/0.3.0/404.html
@@ -1248,8 +1248,6 @@
     
       <script src="/polaris-hub/polaris/0.3.0/assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/adapters.html
+++ b/0.3.0/api/adapters.html
@@ -1575,8 +1575,6 @@ Adapters are serializable and can thus be saved alongside datasets.</p>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/base.html
+++ b/0.3.0/api/base.html
@@ -1721,8 +1721,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/benchmark.html
+++ b/0.3.0/api/benchmark.html
@@ -2466,8 +2466,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/converters.html
+++ b/0.3.0/api/converters.html
@@ -1857,8 +1857,6 @@ to a single column and each array contains the values for all datapoints in that
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/dataset.html
+++ b/0.3.0/api/dataset.html
@@ -2458,8 +2458,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/evaluation.html
+++ b/0.3.0/api/evaluation.html
@@ -1905,8 +1905,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/factory.html
+++ b/0.3.0/api/factory.html
@@ -2090,8 +2090,6 @@ For creating more complicated datasets, please use the <code>DatasetFactory</cod
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/hub.client.html
+++ b/0.3.0/api/hub.client.html
@@ -2917,8 +2917,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/hub.polarisfs.html
+++ b/0.3.0/api/hub.polarisfs.html
@@ -2176,8 +2176,6 @@ as a placeholder that aligns with the Zarr interface's expectations.</p>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/load.html
+++ b/0.3.0/api/load.html
@@ -1521,8 +1521,6 @@ and can be part of <em>one or multiple benchmarks</em>.</p>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/subset.html
+++ b/0.3.0/api/subset.html
@@ -1543,8 +1543,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/api/utils.types.html
+++ b/0.3.0/api/utils.types.html
@@ -2193,8 +2193,6 @@ The externalId and type are added to be consistent with the model returned by th
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/community/community.html
+++ b/0.3.0/community/community.html
@@ -1312,8 +1312,6 @@
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/index.html
+++ b/0.3.0/index.html
@@ -1491,8 +1491,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/quickstart.html
+++ b/0.3.0/quickstart.html
@@ -1556,8 +1556,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/tutorials/basics.html
+++ b/0.3.0/tutorials/basics.html
@@ -3007,8 +3007,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/tutorials/custom_dataset_benchmark.html
+++ b/0.3.0/tutorials/custom_dataset_benchmark.html
@@ -2875,8 +2875,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/tutorials/data_curation.html
+++ b/0.3.0/tutorials/data_curation.html
@@ -2535,8 +2535,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/tutorials/dataset_factory.html
+++ b/0.3.0/tutorials/dataset_factory.html
@@ -2710,8 +2710,6 @@ dataset = factory.build()</div>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.3.0/tutorials/dataset_zarr.html
+++ b/0.3.0/tutorials/dataset_zarr.html
@@ -2800,8 +2800,6 @@ fs.ls(SAVE_DIR)</div>
     
       <script src="../assets/javascripts/bundle.3220b9d7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/404.html
+++ b/0.4.1/404.html
@@ -1248,8 +1248,6 @@
     
       <script src="/polaris-hub/polaris/0.4.1/assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/adapters.html
+++ b/0.4.1/api/adapters.html
@@ -1575,8 +1575,6 @@ Adapters are serializable and can thus be saved alongside datasets.</p>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/base.html
+++ b/0.4.1/api/base.html
@@ -1721,8 +1721,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/benchmark.html
+++ b/0.4.1/api/benchmark.html
@@ -2480,8 +2480,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/converters.html
+++ b/0.4.1/api/converters.html
@@ -1857,8 +1857,6 @@ to a single column and each array contains the values for all datapoints in that
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/dataset.html
+++ b/0.4.1/api/dataset.html
@@ -2458,8 +2458,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/evaluation.html
+++ b/0.4.1/api/evaluation.html
@@ -2014,8 +2014,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/factory.html
+++ b/0.4.1/api/factory.html
@@ -2090,8 +2090,6 @@ For creating more complicated datasets, please use the <code>DatasetFactory</cod
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/hub.client.html
+++ b/0.4.1/api/hub.client.html
@@ -2917,8 +2917,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/hub.polarisfs.html
+++ b/0.4.1/api/hub.polarisfs.html
@@ -2176,8 +2176,6 @@ as a placeholder that aligns with the Zarr interface's expectations.</p>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/load.html
+++ b/0.4.1/api/load.html
@@ -1521,8 +1521,6 @@ and can be part of <em>one or multiple benchmarks</em>.</p>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/subset.html
+++ b/0.4.1/api/subset.html
@@ -1543,8 +1543,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/api/utils.types.html
+++ b/0.4.1/api/utils.types.html
@@ -2193,8 +2193,6 @@ The externalId and type are added to be consistent with the model returned by th
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/community/community.html
+++ b/0.4.1/community/community.html
@@ -1312,8 +1312,6 @@
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/index.html
+++ b/0.4.1/index.html
@@ -1491,8 +1491,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/quickstart.html
+++ b/0.4.1/quickstart.html
@@ -1556,8 +1556,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/tutorials/basics.html
+++ b/0.4.1/tutorials/basics.html
@@ -3007,8 +3007,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/tutorials/custom_dataset_benchmark.html
+++ b/0.4.1/tutorials/custom_dataset_benchmark.html
@@ -2875,8 +2875,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/tutorials/data_curation.html
+++ b/0.4.1/tutorials/data_curation.html
@@ -2535,8 +2535,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/tutorials/dataset_factory.html
+++ b/0.4.1/tutorials/dataset_factory.html
@@ -2710,8 +2710,6 @@ dataset = factory.build()</div>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.4.1/tutorials/dataset_zarr.html
+++ b/0.4.1/tutorials/dataset_zarr.html
@@ -2800,8 +2800,6 @@ fs.ls(SAVE_DIR)</div>
     
       <script src="../assets/javascripts/bundle.dd8806f2.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/404.html
+++ b/0.5.0/404.html
@@ -1269,8 +1269,6 @@
     
       <script src="/polaris-hub/polaris/0.5.0/assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/adapters.html
+++ b/0.5.0/api/adapters.html
@@ -1594,8 +1594,6 @@ Adapters are serializable and can thus be saved alongside datasets.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/base.html
+++ b/0.5.0/api/base.html
@@ -1735,8 +1735,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/benchmark.html
+++ b/0.5.0/api/benchmark.html
@@ -2485,8 +2485,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/converters.html
+++ b/0.5.0/api/converters.html
@@ -1872,8 +1872,6 @@ to a single column and each array contains the values for all datapoints in that
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/dataset.html
+++ b/0.5.0/api/dataset.html
@@ -2559,8 +2559,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/evaluation.html
+++ b/0.5.0/api/evaluation.html
@@ -2023,8 +2023,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/factory.html
+++ b/0.5.0/api/factory.html
@@ -2093,8 +2093,6 @@ For creating more complicated datasets, please use the <code>DatasetFactory</cod
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/hub.client.html
+++ b/0.5.0/api/hub.client.html
@@ -2899,8 +2899,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/hub.polarisfs.html
+++ b/0.5.0/api/hub.polarisfs.html
@@ -2177,8 +2177,6 @@ as a placeholder that aligns with the Zarr interface's expectations.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/load.html
+++ b/0.5.0/api/load.html
@@ -1540,8 +1540,6 @@ and can be part of <em>one or multiple benchmarks</em>.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/subset.html
+++ b/0.5.0/api/subset.html
@@ -1563,8 +1563,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/api/utils.types.html
+++ b/0.5.0/api/utils.types.html
@@ -2211,8 +2211,6 @@ The externalId and type are added to be consistent with the model returned by th
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/community/community.html
+++ b/0.5.0/community/community.html
@@ -1333,8 +1333,6 @@
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/index.html
+++ b/0.5.0/index.html
@@ -1512,8 +1512,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/quickstart.html
+++ b/0.5.0/quickstart.html
@@ -1577,8 +1577,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/tutorials/basics.html
+++ b/0.5.0/tutorials/basics.html
@@ -3028,8 +3028,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/tutorials/custom_dataset_benchmark.html
+++ b/0.5.0/tutorials/custom_dataset_benchmark.html
@@ -2896,8 +2896,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/tutorials/data_curation.html
+++ b/0.5.0/tutorials/data_curation.html
@@ -2556,8 +2556,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/tutorials/dataset_factory.html
+++ b/0.5.0/tutorials/dataset_factory.html
@@ -2731,8 +2731,6 @@ dataset = factory.build()</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/tutorials/dataset_zarr.html
+++ b/0.5.0/tutorials/dataset_zarr.html
@@ -2821,8 +2821,6 @@ fs.ls(SAVE_DIR)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/0.5.0/tutorials/optimization.html
+++ b/0.5.0/tutorials/optimization.html
@@ -2612,8 +2612,6 @@ rmtree(tmpdir)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/404.html
+++ b/stable/404.html
@@ -1269,8 +1269,6 @@
     
       <script src="/polaris-hub/polaris/stable/assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/adapters.html
+++ b/stable/api/adapters.html
@@ -1594,8 +1594,6 @@ Adapters are serializable and can thus be saved alongside datasets.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/base.html
+++ b/stable/api/base.html
@@ -1735,8 +1735,6 @@ Together with the name, this is used by the Hub to uniquely identify the benchma
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/benchmark.html
+++ b/stable/api/benchmark.html
@@ -2485,8 +2485,6 @@ this class verifies that there are multiple target-columns.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/converters.html
+++ b/stable/api/converters.html
@@ -1872,8 +1872,6 @@ to a single column and each array contains the values for all datapoints in that
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/dataset.html
+++ b/stable/api/dataset.html
@@ -2559,8 +2559,6 @@ and while it does not affect logic in this library, it does affect the logic of 
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/evaluation.html
+++ b/stable/api/evaluation.html
@@ -2023,8 +2023,6 @@ and is associated with additional metadata in a <code>MetricInfo</code> instance
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/factory.html
+++ b/stable/api/factory.html
@@ -2093,8 +2093,6 @@ For creating more complicated datasets, please use the <code>DatasetFactory</cod
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/hub.client.html
+++ b/stable/api/hub.client.html
@@ -2899,8 +2899,6 @@ Make sure to specify an existing dataset or upload the dataset first.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/hub.polarisfs.html
+++ b/stable/api/hub.polarisfs.html
@@ -2177,8 +2177,6 @@ as a placeholder that aligns with the Zarr interface's expectations.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/load.html
+++ b/stable/api/load.html
@@ -1540,8 +1540,6 @@ and can be part of <em>one or multiple benchmarks</em>.</p>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/subset.html
+++ b/stable/api/subset.html
@@ -1563,8 +1563,6 @@ To easily build framework-specific data-loaders, a <code>Subset</code> supports 
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/api/utils.types.html
+++ b/stable/api/utils.types.html
@@ -2211,8 +2211,6 @@ The externalId and type are added to be consistent with the model returned by th
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/community/community.html
+++ b/stable/community/community.html
@@ -1333,8 +1333,6 @@
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/index.html
+++ b/stable/index.html
@@ -1512,8 +1512,6 @@ and adaptive standard for measuring progress of computational tools in drug disc
     
       <script src="assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/quickstart.html
+++ b/stable/quickstart.html
@@ -1577,8 +1577,6 @@ a variety of high-quality datasets, benchmarks and associated results.</p>
     
       <script src="assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/tutorials/basics.html
+++ b/stable/tutorials/basics.html
@@ -3028,8 +3028,6 @@ client.close()</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/tutorials/custom_dataset_benchmark.html
+++ b/stable/tutorials/custom_dataset_benchmark.html
@@ -2896,8 +2896,6 @@ fs.ls(save_dir)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/tutorials/data_curation.html
+++ b/stable/tutorials/data_curation.html
@@ -2556,8 +2556,6 @@ check_undefined_stereocenters(df_curated)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/tutorials/dataset_factory.html
+++ b/stable/tutorials/dataset_factory.html
@@ -2731,8 +2731,6 @@ dataset = factory.build()</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/tutorials/dataset_zarr.html
+++ b/stable/tutorials/dataset_zarr.html
@@ -2821,8 +2821,6 @@ fs.ls(SAVE_DIR)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     

--- a/stable/tutorials/optimization.html
+++ b/stable/tutorials/optimization.html
@@ -2612,8 +2612,6 @@ rmtree(tmpdir)</div>
     
       <script src="../assets/javascripts/bundle.ad660dcc.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-      
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       
     


### PR DESCRIPTION
## Changelogs

- Removed the `polyfill` JS from our documentation

---

This is a hotfix needed due to a supply chain attack. See https://thehackernews.com/2024/06/over-110000-websites-affected-by.html
