### PR TITLE
Install `mkdocs-jupyter` from conda instead of PyPi in the CICD

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,11 +31,7 @@ jobs:
           cache-downloads: true
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps .
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/30
-          python -m pip install mkdocs-jupyter -U
+        run: python -m pip install --no-deps .
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,11 +100,7 @@ jobs:
           git push origin "${{ inputs.release-version }}"
 
       - name: Install library
-        run: |
-          python -m pip install --no-deps .
-          # Note: Temporarily upgrade mkdocs-jupyter through PyPi
-          # See https://github.com/conda-forge/mkdocs-jupyter-feedstock/pull/29
-          python -m pip install mkdocs-jupyter -U
+        run: python -m pip install --no-deps .
 
       - name: Build the wheel and sdist
         run: python -m build --no-isolation


### PR DESCRIPTION
## Changelogs

- Install `mkdocs-jupyter` from conda instead of PyPi in the CICD

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

For details, see https://github.com/conda-forge/mkdocs-jupyter-feedstock/issues/31
