### PR TITLE
Allow an empty train partition to support test-set only (e.g. zero-shot) benchmarks

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -174,9 +174,8 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         # Train partition can be empty (zero-shot)
         # Test partitions cannot be empty
-        if (
-            (isinstance(v[1], dict) and any(len(v) == 0 for v in v[1].values()))
-            or (not isinstance(v[1], dict) and len(v[1]) == 0)
+        if (isinstance(v[1], dict) and any(len(v) == 0 for v in v[1].values())) or (
+            not isinstance(v[1], dict) and len(v[1]) == 0
         ):
             raise InvalidBenchmarkError("The predefined split contains empty test partitions")
 

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -6,6 +6,7 @@ import fsspec
 import numpy as np
 import pandas as pd
 from datamol.utils import fs
+from loguru import logger
 from pydantic import (
     Field,
     ValidationInfo,
@@ -178,6 +179,11 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
             not isinstance(v[1], dict) and len(v[1]) == 0
         ):
             raise InvalidBenchmarkError("The predefined split contains empty test partitions")
+
+        if len(v[0]) == 0:
+            logger.info(
+                "This benchmark only specifies a test set. It will return an empty train set in `get_train_test_split()`"
+            )
 
         train_indices = v[0]
         test_indices = [i for part in v[1].values() for i in part] if isinstance(v[1], dict) else v[1]

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -166,19 +166,19 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
     def _validate_split(cls, v, info: ValidationInfo):
         """
         Verifies that:
-          1) There is at least two, non-empty partitions
+          1) There are no empty test partitions
           2) All indices are valid given the dataset
           3) There is no duplicate indices in any of the sets
           3) There is no overlap between the train and test set
         """
 
-        # There is at least two, non-empty partitions
+        # Train partition can be empty (zero-shot)
+        # Test partitions cannot be empty
         if (
-            len(v[0]) == 0
-            or (isinstance(v[1], dict) and any(len(v) == 0 for v in v[1].values()))
+            (isinstance(v[1], dict) and any(len(v) == 0 for v in v[1].values()))
             or (not isinstance(v[1], dict) and len(v[1]) == 0)
         ):
-            raise InvalidBenchmarkError("The predefined split contains empty partitions")
+            raise InvalidBenchmarkError("The predefined split contains empty test partitions")
 
         train_indices = v[0]
         test_indices = [i for part in v[1].values() for i in part] if isinstance(v[1], dict) else v[1]

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -56,7 +56,9 @@ def test_split_verification(is_single_task, test_single_task_benchmark, test_mul
     # It should _not_ fail with missing indices
     cls(split=(train_split[:-1], test_split), **default_kwargs)
     # It should _not_ fail with an empty train set
-    cls(split=([], test_split), **default_kwargs)
+    benchmark = cls(split=([], test_split), **default_kwargs)
+    train, _ = benchmark.get_train_test_split()
+    assert len(train) == 0
 
 
 @pytest.mark.parametrize("cls", [SingleTaskBenchmarkSpecification, MultiTaskBenchmarkSpecification])

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -27,7 +27,7 @@ def test_split_verification(is_single_task, test_single_task_benchmark, test_mul
     train_split = obj.split[0]
     test_split = obj.split[1]
 
-    # One or more empty partitions
+    # One or more empty test partitions
     with pytest.raises(ValidationError):
         cls(split=(train_split,), **default_kwargs)
     with pytest.raises(ValidationError):
@@ -55,6 +55,8 @@ def test_split_verification(is_single_task, test_single_task_benchmark, test_mul
         cls(split=(train_split, test_split + test_split[:1]), **default_kwargs)
     # It should _not_ fail with missing indices
     cls(split=(train_split[:-1], test_split), **default_kwargs)
+    # It should _not_ fail with an empty train set
+    cls(split=([], test_split), **default_kwargs)
 
 
 @pytest.mark.parametrize("cls", [SingleTaskBenchmarkSpecification, MultiTaskBenchmarkSpecification])


### PR DESCRIPTION
This PR enables the definition of zero-shot benchmarks by allowing the train partition of `BenchmarkSpecification` to be an empty list. See #131 

## Changelogs

- No more `InvalidBenchmarkError` is raised when `v[0]` is empty in `_validate_split`
- Error message and docstring was adjusted accordingly
---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._ #131 
- [x] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
