### PR TITLE
fix: Issue where a None token breaks the login flow

### DIFF
--- a/polaris/hub/external_auth_client.py
+++ b/polaris/hub/external_auth_client.py
@@ -117,7 +117,7 @@ class ExternalAuthClient(OAuth2Client):
         """
 
         # Check if the user is already logged in
-        token_is_valid = self.ensure_active_token(self.token)
+        token_is_valid = self.token is not None and self.ensure_active_token(self.token)
         if token_is_valid and not overwrite:
             try:
                 info = self.user_info


### PR DESCRIPTION
## Changelogs

This PR adds a check, in the external auth token, for the existence of the token before checking its validity. This will prevent an error that breaks the login flow for users who have no cached external auth 
token.

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

-

_discussion related to that PR_
