### PR TITLE
Only adding zarrRootPath field to datasets that use Zarr

### DIFF
--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -474,8 +474,9 @@ class PolarisHubClient(OAuth2Client):
         dataset.owner = HubOwner.normalize(owner or dataset.owner)
         dataset_json = dataset.model_dump(exclude={"cache_dir", "table"}, exclude_none=True, by_alias=True)
 
-        # We will save the Zarr archive to the Hub as well
-        dataset_json["zarrRootPath"] = f"{PolarisFileSystem.protocol}://data.zarr"
+        # If the dataset uses Zarr, we will save the Zarr archive to the Hub as well
+        if dataset.uses_zarr:
+            dataset_json["zarrRootPath"] = f"{PolarisFileSystem.protocol}://data.zarr"
 
         # Uploading a dataset is a three-step process.
         # 1. Upload the dataset meta data to the hub and prepare the hub to receive the data


### PR DESCRIPTION
## Changelogs

Updating the `client.upload_dataset` method to only add the `zarrRootPath` field to datasets which make use of Zarr. Otherwise, datasets which do not use make use of Zarr will fail a validation check and cannot be uploaded. 

---

_Checklist:_

~- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
~- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
