### PR TITLE
Fix undefined split during checksum calc with multiple test sets

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -277,7 +277,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
         if not isinstance(self.split[1], dict):
             split = self.split[0], {"test": self.split[1]}
         else:
-            split = self.split[0], self.split[1]
+            split = self.split
 
         # Train set
         s = json.dumps(sorted(split[0]))

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -276,6 +276,8 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         if not isinstance(self.split[1], dict):
             split = self.split[0], {"test": self.split[1]}
+        else:
+            split = self.split[0], self.split[1]
 
         # Train set
         s = json.dumps(sorted(split[0]))


### PR DESCRIPTION
## Changelogs

When computing the hash for a benchmark, the benchmark split is included in the hash calculation. The current calculation logic works fine when there is a single test set, but errors when multiple are specified. 

This is because a `split` variable is defined and used during the calculation, but it is only defined when a single test set is specified. This PR ensures the `split` variable is defined in the case of multiple test sets.

---

_Checklist:_

~- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
~- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
~- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._~
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---