### PR TITLE
Updating `base_request_to_hub` method to allow handling of responses without json

### DIFF
--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -175,8 +175,8 @@ class PolarisHubClient(OAuth2Client):
                 raise
 
             # If JSON is included in the response body, we retrieve it and format it for output. If not, we fallback to
-            # retrieving plain text from the body. This is important for handling large payloads that our backend may reject,
-            # resulting in a non-JSON error response.
+            # retrieving plain text from the body. This is important for handling certain errors thrown from the backend
+            # which do not contain JSON in the response.
             try:
                 response = response.json()
                 response = json.dumps(response, indent=2, sort_keys=True)

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -174,14 +174,17 @@ class PolarisHubClient(OAuth2Client):
             if response_status_code == 500:
                 raise
 
-            # If not an internal server error, the hub should always return a JSON response
-            # with additional information about the error.
-            response = response.json()
-            response = json.dumps(response, indent=2, sort_keys=True)
+            # If JSON is included in the response body, we retrieve it and format it for output. If not, we retrieve
+            # the string representation of the response body and move forward
+            try:
+                response = response.json()
+                response = json.dumps(response, indent=2, sort_keys=True)
+            except json.JSONDecodeError:
+                response = response.text
+                pass
 
             # The below two error cases can happen due to the JWT token containing outdated information.
             # We therefore throw a custom error with a recommended next step.
-
             if response_status_code == 403:
                 # This happens when trying to create an artifact for an owner the user has no access to.
                 raise PolarisCreateArtifactError(response=response) from error

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -179,7 +179,7 @@ class PolarisHubClient(OAuth2Client):
             try:
                 response = response.json()
                 response = json.dumps(response, indent=2, sort_keys=True)
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, TypeError):
                 response = response.text
 
             # The below two error cases can happen due to the JWT token containing outdated information.

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -181,7 +181,6 @@ class PolarisHubClient(OAuth2Client):
                 response = json.dumps(response, indent=2, sort_keys=True)
             except json.JSONDecodeError:
                 response = response.text
-                pass
 
             # The below two error cases can happen due to the JWT token containing outdated information.
             # We therefore throw a custom error with a recommended next step.

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -174,8 +174,9 @@ class PolarisHubClient(OAuth2Client):
             if response_status_code == 500:
                 raise
 
-            # If JSON is included in the response body, we retrieve it and format it for output. If not, we retrieve
-            # the string representation of the response body and move forward
+            # If JSON is included in the response body, we retrieve it and format it for output. If not, we fallback to
+            # retrieving plain text from the body. This is important for handling large payloads that our backend may reject,
+            # resulting in a non-JSON error response.
             try:
                 response = response.json()
                 response = json.dumps(response, indent=2, sort_keys=True)


### PR DESCRIPTION
## Changelogs

- Wrapped the JSON parsing of an HTTP response's body in a `try...except` block. This prevents a `JSONDecodeError` in the event the response does not include JSON. This allows the error to still be handled in a meaningful manner. Errors returned from the Hub should be unaffected and output in the same fashion. 

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._ Yes: https://github.com/polaris-hub/polaris/issues/149
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
