### PR TITLE
Add examples in evaluation docstring

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -415,7 +415,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
             2. For classification benchmarks:
                 - If `roc_auc` and `pr_auc` in the metric list, both class probabilities and label predictions are required:
                     pred_probs = model.predict_proba(molecules) # predict probablities
-                    pred_labels = model.predict_lables(molecules) # predict class labels
+                    pred_labels = model.predict_labels(molecules) # predict class labels
                     benchmark.evaluate(y_pred=prediction_labels, y_prob=pred_labels)
                 - Otherwise:
                     benchmark.evaluate(y_pred=prediction_labels)

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -410,7 +410,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         Examples:
             1. For regression benchmarks:
-                pred_scores = your_model.predict_score(molecules) # predict continous score values
+                pred_scores = your_model.predict_score(molecules) # predict continuous score values
                 benchmark.evaluate(y_pred=pred_scores)
             2. For classification benchmarks:
                 - If `roc_auc` and `pr_auc` are in the metric list, both class probabilities and label predictions are required:

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -410,15 +410,15 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         Examples:
             1. For regression benchmarks:
-                predictions = model.predict(molecules)
-                benchmark.evaluate(y_pred=prediction_labels)
+                pred_scores = model.predict(molecules) # predict continous score values
+                benchmark.evaluate(y_pred=pred_scores)
             2. For classification benchmarks:
-                - If `roc_auc` and `pr_auc` in the metric list, both class probabilities and label predictions are required:
-                    pred_probs = model.predict_proba(molecules) # predict probablities
-                    pred_labels = model.predict_labels(molecules) # predict class labels
+                - If `roc_auc` and `pr_auc` are in the metric list, both class probabilities and label predictions are required:
+                    pred_probs = your_model.predict_proba(molecules) # predict probablities
+                    pred_labels = your_model.predict_labels(molecules) # predict class labels
                     benchmark.evaluate(y_pred=pred_labels, y_prob=pred_probs)
                 - Otherwise:
-                    benchmark.evaluate(y_pred=prediction_labels)
+                    benchmark.evaluate(y_pred=pred_labels)
         """
 
         # Instead of having the user pass the ground truth, we extract it from the benchmark spec ourselves.

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -410,7 +410,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         Examples:
             1. For regression benchmarks:
-                pred_scores = model.predict(molecules) # predict continous score values
+                pred_scores = your_model.predict_score(molecules) # predict continous score values
                 benchmark.evaluate(y_pred=pred_scores)
             2. For classification benchmarks:
                 - If `roc_auc` and `pr_auc` are in the metric list, both class probabilities and label predictions are required:

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -416,7 +416,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
                 - If `roc_auc` and `pr_auc` in the metric list, both class probabilities and label predictions are required:
                     pred_probs = model.predict_proba(molecules) # predict probablities
                     pred_labels = model.predict_labels(molecules) # predict class labels
-                    benchmark.evaluate(y_pred=prediction_labels, y_prob=pred_labels)
+                    benchmark.evaluate(y_pred=pred_labels, y_prob=pred_probs)
                 - Otherwise:
                     benchmark.evaluate(y_pred=prediction_labels)
         """

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -406,6 +406,19 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         Returns:
             A `BenchmarkResults` object. This object can be directly submitted to the Polaris Hub.
+
+
+        Examples:
+            1. For regression benchmarks:
+                predictions = model.predict(molecules)
+                benchmark.evaluate(y_pred=prediction_labels)
+            2. For classification benchmarks:
+                - If `roc_auc` and `pr_auc` in the metric list, both class probabilities and label predictions are required:
+                    pred_probs = model.predict_proba(molecules) # predict probablities
+                    pred_labels = model.predict_lables(molecules) # predict class labels
+                    benchmark.evaluate(y_pred=prediction_labels, y_prob=pred_labels)
+                - Otherwise:
+                    benchmark.evaluate(y_pred=prediction_labels)
         """
 
         # Instead of having the user pass the ground truth, we extract it from the benchmark spec ourselves.

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -169,7 +169,7 @@ def test_metric_y_types(
 
     # If y_type != "y_pred" and y_prob is None, an error is thrown.
     with pytest.raises(ValueError, match="Metric.roc_auc requires `y_prob` input"):
-        test_single_task_benchmark_clf.metrics = [Metric.roc_auc]
+        test_single_task_benchmark_clf.metrics = [Metric.roc_auc, Metric.pr_auc]
         test_single_task_benchmark_clf.evaluate(y_pred=predictions)
 
     # If y_type != "y_pred" and y_pred is not None and y_prob is not None, it uses y_prob as expected!

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -169,7 +169,12 @@ def test_metric_y_types(
 
     # If y_type != "y_pred" and y_prob is None, an error is thrown.
     with pytest.raises(ValueError, match="Metric.roc_auc requires `y_prob` input"):
-        test_single_task_benchmark_clf.metrics = [Metric.roc_auc, Metric.pr_auc]
+        test_single_task_benchmark_clf.metrics = [Metric.roc_auc]
+        test_single_task_benchmark_clf.evaluate(y_pred=predictions)
+
+    # If y_type != "y_pred" and y_prob is None, an error is thrown.
+    with pytest.raises(ValueError, match="Metric.pr_auc requires `y_prob` input"):
+        test_single_task_benchmark_clf.metrics = [Metric.pr_auc]
         test_single_task_benchmark_clf.evaluate(y_pred=predictions)
 
     # If y_type != "y_pred" and y_pred is not None and y_prob is not None, it uses y_prob as expected!


### PR DESCRIPTION
## Changelogs

- Added example in `benchmark.evaluation` docstrings to clarify the evaluation inputs.
