### PR TITLE
Updating split validator to allow duplicates across test sets

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -182,9 +182,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
             raise InvalidBenchmarkError("The predefined split contains empty test partitions")
 
         train_idx_list = v[0]
-        full_test_idx_list = (
-            list(i for part in v[1].values() for i in part) if isinstance(v[1], dict) else v[1]
-        )
+        full_test_idx_list = list(chain.from_iterable(v[1].values())) if isinstance(v[1], dict) else v[1]
 
         if len(train_idx_list) == 0:
             logger.info(
@@ -207,8 +205,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
         # across test sets, we check for duplicates in each test set independently.
         if isinstance(v[1], dict):
             for test_set_name, test_set_idx_list in v[1].items():
-                test_set_idx_set = set(test_set_idx_list)
-                if len(test_set_idx_list) != len(test_set_idx_set):
+                if len(test_set_idx_list) != len(set(test_set_idx_list)):
                     raise InvalidBenchmarkError(
                         f'Test set with name "{test_set_name}" contains duplicate indices'
                     )

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -251,7 +251,6 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
                     v[target] = TargetType.CLASSIFICATION
                 else:
                     v[target] = None
-
             elif not isinstance(v, TargetType):
                 v[target] = TargetType(v[target])
         return v

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -252,7 +252,6 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
                 else:
                     v[target] = None
 
-                print(v[target])
             elif not isinstance(v, TargetType):
                 v[target] = TargetType(v[target])
         return v

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -212,9 +212,8 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
                     raise InvalidBenchmarkError(
                         f'Test set with name "{test_set_name}" contains duplicate indices'
                     )
-        else:
-            if len(full_test_idx_set) != len(full_test_idx_list):
-                raise InvalidBenchmarkError("The test set contains duplicate indices")
+        elif len(full_test_idx_set) != len(full_test_idx_list):
+            raise InvalidBenchmarkError("The test set contains duplicate indices")
 
         # All indices are valid given the dataset
         if info.data["dataset"] is not None:

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -219,7 +219,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
         # All indices are valid given the dataset
         if info.data["dataset"] is not None:
             max_i = len(info.data["dataset"])
-            if any(i < 0 or i >= max_i for i in chain(train_idx_list, full_test_idx_list)):
+            if any(i < 0 or i >= max_i for i in chain(train_idx_list, full_test_idx_set)):
                 raise InvalidBenchmarkError("The predefined split contains invalid indices")
 
         return v

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -53,6 +53,13 @@ def test_split_verification(is_single_task, test_single_task_benchmark, test_mul
         cls(split=(train_split + train_split[:1], test_split), **default_kwargs)
     with pytest.raises(ValidationError):
         cls(split=(train_split, test_split + test_split[:1]), **default_kwargs)
+    with pytest.raises(ValidationError):
+        cls(
+            split=(train_split, {"test1": test_split, "test2": test_split + test_split[:1]}), **default_kwargs
+        )
+
+    # It should _not_ fail with duplicate indices across test partitions
+    cls(split=(train_split, {"test1": test_split, "test2": test_split}), **default_kwargs)
     # It should _not_ fail with missing indices
     cls(split=(train_split[:-1], test_split), **default_kwargs)
     # It should _not_ fail with an empty train set


### PR DESCRIPTION
## Changelogs

- Updating the `split` field validator in the `BenchmarkSpecification` model to check for duplicates _within_ individual test sets rather than _across_ all test sets
- Added test to ensure duplicates in a nested test set are caught
- Added test to ensure that duplicate indices are allowed across indices

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._ https://github.com/polaris-hub/polaris/issues/157
- [x] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
