### PR TITLE
Updating dataset upload to respect `Dataset` name

### DIFF
--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -679,7 +679,7 @@ class PolarisHubClient(OAuth2Client):
             benchmark_json["datasetArtifactId"] = benchmark.dataset.artifact_id
             benchmark_json["access"] = access
 
-            url = f"/benchmark/{benchmark.owner}/{benchmark.name}"
+            url = f"/benchmark/{benchmark.artifact_id}"
             response = self._base_request_to_hub(url=url, method="PUT", json=benchmark_json)
 
             progress_indicator.update_success_msg(

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -684,7 +684,7 @@ class PolarisHubClient(OAuth2Client):
 
             progress_indicator.update_success_msg(
                 "Your benchmark has been successfully uploaded to the Hub. "
-                f"View it here: {urljoin(self.settings.hub_url, f'benchmarks/{benchmark.owner}/{benchmark.name}')}"
+                f"View it here: {urljoin(self.settings.hub_url, f'benchmarks/{benchmark.artifact_id}')}"
             )
 
             return response

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -635,7 +635,7 @@ class PolarisHubClient(OAuth2Client):
 
             progress_indicator.update_success_msg(
                 "Your dataset has been successfully uploaded to the Hub. "
-                f"View it here: {urljoin(self.settings.hub_url, f'datasets/{dataset.owner}/{dataset.name}')}"
+                f"View it here: {urljoin(self.settings.hub_url, f'datasets/{dataset.artifact_id}')}"
             )
 
             return response

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -557,7 +557,7 @@ class PolarisHubClient(OAuth2Client):
             # Step 1: Upload meta-data
             # Instead of directly uploading the data, we announce to the hub that we intend to upload it.
             # We do so separately for the Zarr archive and Parquet file.
-            url = f"/dataset/{dataset.artifact_id}"
+            url = f"/dataset/{dataset.owner}/{dataset.name}"
             response = self._base_request_to_hub(
                 url=url,
                 method="PUT",
@@ -635,7 +635,7 @@ class PolarisHubClient(OAuth2Client):
 
             progress_indicator.update_success_msg(
                 "Your dataset has been successfully uploaded to the Hub. "
-                f"View it here: {urljoin(self.settings.hub_url, f'datasets/{dataset.artifact_id}')}"
+                f"View it here: {urljoin(self.settings.hub_url, f'datasets/{dataset.owner}/{dataset.name}')}"
             )
 
             return response
@@ -679,12 +679,12 @@ class PolarisHubClient(OAuth2Client):
             benchmark_json["datasetArtifactId"] = benchmark.dataset.artifact_id
             benchmark_json["access"] = access
 
-            url = f"/benchmark/{benchmark.artifact_id}"
+            url = f"/benchmark/{benchmark.owner}/{benchmark.name}"
             response = self._base_request_to_hub(url=url, method="PUT", json=benchmark_json)
 
             progress_indicator.update_success_msg(
                 "Your benchmark has been successfully uploaded to the Hub. "
-                f"View it here: {urljoin(self.settings.hub_url, f'benchmarks/{benchmark.artifact_id}')}"
+                f"View it here: {urljoin(self.settings.hub_url, f'benchmarks/{benchmark.owner}/{benchmark.name}')}"
             )
 
             return response


### PR DESCRIPTION
## Changelogs

- ~Updated `client.upload_benchmark` method to use the correct, sluggified `owner/name` combination during benchmark upload.~

- Currently, dataset uploads are completed such that the `name` of the dataset is really the `slug`. These two differ in that `slugs` convert underscores to hyphens whereas `names` do not. Because the `name` and `slug` are separate things, and the name of the dataset should be the name (not the slug), this change ensures that user naming is respected on dataset upload.

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
