### PR TITLE
Improving token errors and quickstart guide 

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,6 +13,20 @@ mamba install -c conda-forge polaris
 ??? info "Other installation options"
 You can replace `mamba` by `conda`. The package is also pip installable if you need it: `pip install polaris-lib`.
 
+## Authenticating to the Polaris Hub
+To interact with the [Polaris Hub](https://polarishub.io/) from the client, you must first login. You can do this
+via the following command in your terminal:
+
+```bash
+polaris login
+```
+
+This will redirect you to a login page on the Polaris Hub where you can either sign in or sign up. Once either
+of these options have been completed, you will see an authorization code on your screen. Copy this and paste it 
+back into your terminal when prompted by the client.
+
+That's it! You're now all set to interact with datasets and benchmarks across Polaris.
+
 ## Benchmarking API
 
 At its core, Polaris is a benchmarking library. It provides a simple API to run benchmarks. While it can be used

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ That's it! You're now all set to interact with datasets and benchmarks across Po
 ## Benchmarking API
 
 At its core, Polaris is a benchmarking library. It provides a simple API to run benchmarks. While it can be used
-independently, it is built to easily integrate with the [Polaris Hub](https://polarishub.io/). The hub hosts
+independently, it is built to easily integrate with the Polaris Hub. The hub hosts
 a variety of high-quality datasets, benchmarks and associated results.
 
 If all you care about is to partake in a benchmark that is hosted on the hub, it is as simple as:

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -217,8 +217,8 @@ class PolarisHubClient(OAuth2Client):
         try:
             return super().request(method, url, withhold_token, auth, **kwargs)
         except httpx.ConnectError as error:
-            # NOTE (cwognum): In the stack-trace, the more specific SSLCertVerificationError is raised.
-            #   We could use the traceback module to cactch this specific error, but that would be overkill here.
+            # NOTE (cwognum): In the stack trace, the more specific SSLCertVerificationError is raised.
+            #   We could use the traceback module to catch this specific error, but that would be overkill here.
             if _HTTPX_SSL_ERROR_CODE in str(error):
                 raise ssl.SSLCertVerificationError(
                     "We could not verify the SSL certificate. "


### PR DESCRIPTION
## Changelogs

- Updated the quickstart guide to include a section about logging in prior to interacting with artifacts on Polaris
- Updated the handling of `client.request` errors such that client-side token errors produce a more useful error message to the user
- Updated the `client.base_request_to_hub` method to provide a more meaningful error message to users when their token expires

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._ Yes: https://github.com/polaris-hub/polaris/issues/163, https://github.com/polaris-hub/polaris/issues/160
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [x] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
