### PR TITLE
Adding correct name of package during version fetch

### DIFF
--- a/polaris/_version.py
+++ b/polaris/_version.py
@@ -1,7 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("polaris")
+    __version__ = version("polaris-lib")
 except PackageNotFoundError:
     # package is not installed
     __version__ = "dev"


### PR DESCRIPTION
## Changelogs

- Updating the name of the package for which we fetch the client version from. It is currently trying to look for `polaris` when it should be looking for `polaris-lib`. This is needed because all incoming bug reports have the version `dev` instead of the actual release version.

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
