### PR TITLE
Remove literal wrappers in KnownContentType definition 

### DIFF
--- a/polaris/dataset/_column.py
+++ b/polaris/dataset/_column.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Dict, Optional, Literal, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 from numpy.typing import DTypeLike

--- a/polaris/dataset/_column.py
+++ b/polaris/dataset/_column.py
@@ -21,8 +21,8 @@ class Modality(enum.Enum):
 class KnownContentType(str, enum.Enum):
     """Used to specify column's IANA content type in a dataset."""
 
-    SMILES = Literal["chemical/x-smiles"]
-    PDB = Literal["chemical/x-pdb"]
+    SMILES = "chemical/x-smiles"
+    PDB = "chemical/x-pdb"
 
 
 class ColumnAnnotation(BaseModel):


### PR DESCRIPTION
## Changelogs

A quick PR to remove the Literal wrappers in KnownContentType definition because it was causing display issues in the data viz table

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
