### PR TITLE
add timeout argument

### DIFF
--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -35,6 +35,7 @@ from polaris.utils.types import (
     HubOwner,
     SupportedLicenseType,
     ZarrConflictResolution,
+    TimeoutTypes,
 )
 
 # Constants
@@ -370,13 +371,16 @@ class Dataset(BaseArtifactModel, ChecksumMixin):
         return arr
 
     def upload_to_hub(
-        self, access: Optional[AccessType] = "private", owner: Union[HubOwner, str, None] = None
+        self,
+        access: Optional[AccessType] = "private",
+        owner: Union[HubOwner, str, None] = None,
+        timeout: TimeoutTypes = (10, 200),
     ):
         """
         Very light, convenient wrapper around the
         [`PolarisHubClient.upload_dataset`][polaris.hub.client.PolarisHubClient.upload_dataset] method.
         """
-        self.client.upload_dataset(self, access=access, owner=owner)
+        self.client.upload_dataset(self, access=access, owner=owner, timeout=timeout)
 
     @classmethod
     def from_json(cls, path: str):


### PR DESCRIPTION
## Changelogs

- Add argument `timeout` to `Dataset.upload_to_hub` function, to keep the consistency to [client function](https://github.com/polaris-hub/polaris/blob/c910f2876ddfae71cf17430035d4bf7a257251eb/polaris/hub/client.py#L537). 

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

The `timeout` argument is crucial for the success of large dataset uploading. 
