### PR TITLE
Add ligand RMSD metrics 

### DIFF
--- a/docs/api/evaluation.md
+++ b/docs/api/evaluation.md
@@ -14,12 +14,15 @@
 
 ::: polaris.evaluate.MetricInfo
 
-::: polaris.evaluate._metric.absolute_average_fold_error
-
 ---
 
 ::: polaris.evaluate.Metric
     options: 
         filters: ["!^_", "!fn", "!is_multitask", "!y_type"]
+
+---
+
+::: polaris.evaluate.metrics.generic_metrics
+::: polaris.evaluate.metrics.docking_metrics
 
 ---

--- a/polaris/evaluate/_metric.py
+++ b/polaris/evaluate/_metric.py
@@ -76,7 +76,7 @@ class MetricInfo(BaseModel):
     is_multitask: bool = False
     kwargs: dict = Field(default_factory=dict)
     direction: DirectionType
-    y_type: Literal["y_pred", "y_prob", "y_score", "structure"] = "y_pred"
+    y_type: Literal["y_pred", "y_prob", "y_score"] = "y_pred"
 
 
 class Metric(Enum):

--- a/polaris/evaluate/_metric.py
+++ b/polaris/evaluate/_metric.py
@@ -17,6 +17,7 @@ from sklearn.metrics import (
     roc_auc_score,
     balanced_accuracy_score,
 )
+from polaris.evaluate.metrics.docking_metrics import rmsd_coverage
 
 from polaris.utils.types import DirectionType
 
@@ -75,7 +76,7 @@ class MetricInfo(BaseModel):
     is_multitask: bool = False
     kwargs: dict = Field(default_factory=dict)
     direction: DirectionType
-    y_type: Literal["y_pred", "y_prob", "y_score"] = "y_pred"
+    y_type: Literal["y_pred", "y_prob", "y_score", "structure"] = "y_pred"
 
 
 class Metric(Enum):
@@ -119,6 +120,9 @@ class Metric(Enum):
         fn=roc_auc_score, kwargs={"multi_class": "ovo"}, direction="max", y_type="y_score"
     )
     # TODO: add metrics to handle multitask multiclass predictions.
+
+    # docking related metrics
+    rmsd_coverage = MetricInfo(fn=rmsd_coverage, direction="max", y_type="y_pred")
 
     @property
     def fn(self) -> Callable:

--- a/polaris/evaluate/_metric.py
+++ b/polaris/evaluate/_metric.py
@@ -3,11 +3,10 @@ from typing import Callable, Literal, Optional
 
 import numpy as np
 from pydantic import BaseModel, Field
-from scipy import stats
+
 from sklearn.metrics import (
     accuracy_score,
     average_precision_score,
-    cohen_kappa_score as sk_cohen_kappa_score,
     explained_variance_score,
     f1_score,
     matthews_corrcoef,
@@ -17,48 +16,16 @@ from sklearn.metrics import (
     roc_auc_score,
     balanced_accuracy_score,
 )
+
+from polaris.evaluate.metrics import (
+    cohen_kappa_score,
+    absolute_average_fold_error,
+    spearman,
+    pearsonr,
+)
 from polaris.evaluate.metrics.docking_metrics import rmsd_coverage
 
 from polaris.utils.types import DirectionType
-
-
-def pearsonr(y_true: np.ndarray, y_pred: np.ndarray):
-    """Calculate a pearson r correlation"""
-    return stats.pearsonr(y_true, y_pred).statistic
-
-
-def spearman(y_true: np.ndarray, y_pred: np.ndarray):
-    """Calculate a Spearman correlation"""
-    return stats.spearmanr(y_true, y_pred).statistic
-
-
-def absolute_average_fold_error(y_true: np.ndarray, y_pred: np.ndarray) -> float:
-    """
-    Calculate the Absolute Average Fold Error (AAFE) metric.
-    It measures the fold change between predicted values and observed values.
-    The implementation is based on [this paper](https://pubs.acs.org/doi/10.1021/acs.chemrestox.3c00305).
-
-    Args:
-        y_true: The true target values of shape (n_samples,)
-        y_pred: The predicted target values of shape (n_samples,).
-
-    Returns:
-        aafe: The Absolute Average Fold Error.
-    """
-    if len(y_true) != len(y_pred):
-        raise ValueError("Length of y_true and y_pred must be the same.")
-
-    if np.any(y_true == 0):
-        raise ValueError("`y_true` contains zero which will result `Inf` value.")
-
-    aafe = np.mean(np.abs(y_pred) / np.abs(y_true))
-
-    return aafe
-
-
-def cohen_kappa_score(y_true, y_pred, **kwargs):
-    """Scikit learn cohen_kappa_score wraper with renamed arguments"""
-    return sk_cohen_kappa_score(y1=y_true, y2=y_pred, **kwargs)
 
 
 class MetricInfo(BaseModel):

--- a/polaris/evaluate/metrics/__init__.py
+++ b/polaris/evaluate/metrics/__init__.py
@@ -1,0 +1,7 @@
+from polaris.evaluate.metrics.generic_metrics import (
+    cohen_kappa_score,
+    absolute_average_fold_error,
+    spearman,
+    pearsonr,
+)
+from polaris.evaluate.metrics.docking_metrics import rmsd_coverage

--- a/polaris/evaluate/metrics/docking_metrics.py
+++ b/polaris/evaluate/metrics/docking_metrics.py
@@ -19,7 +19,7 @@ def _rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol) -> float:
             present, the lowest RMSD will be reported.
 
     Returns:
-        PoseBusters results dictionary.
+        Returns the RMS between two molecules, taking symmetry into account.
     """
 
     # copy the molecule for modification.

--- a/polaris/evaluate/metrics/docking_metrics.py
+++ b/polaris/evaluate/metrics/docking_metrics.py
@@ -1,20 +1,42 @@
 # This script includes docking related evaluation metrics.
 
 from typing import Union, List
-from copy import deepcopy
 
 import numpy as np
-from rdkit.Chem.rdMolAlign import CalcRMS, GetBestRMS
-
+from rdkit.Chem.rdMolAlign import CalcRMS
 import datamol as dm
 
 
 ## The following rmsd implementation are modified based on ppsebusters https://github.com/maabuu/posebusters/blob/main/posebusters/modules/rmsd.py
 
 
-def _call_rdkit_rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol, conf_id_probe: int, conf_id_ref: int, **params):
+def _rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol) -> float:
+    """Calculate RMSD between predicted molecule and closest ground truth molecule.
+       The RMSD is calculated with first conformer of predicted molecule and only consider heavy atoms for RMSD calculation
+
+    Args:
+        mol_probe: Predicted molecule (docked ligand) with exactly one conformer.
+        mol_ref: Ground truth molecule (crystal ligand) with at least one conformer. If multiple conformers are
+            present, the lowest RMSD will be reported.
+
+    Returns:
+        PoseBusters results dictionary.
+    """
+
+    # copy the molecule for modification.
+    mol_probe = dm.copy_mol(mol_probe)
+    mol_ref = dm.copy_mol(mol_ref)
+
+    # remove hydrogen from molecule
+    mol_probe = dm.remove_hs(mol_probe)
+    mol_ref = dm.remove_hs(mol_ref)
+
+    # calculate RMSD
     try:
-        return _rmsd(mol_probe, mol_ref, conf_id_probe, conf_id_ref, **params)
+        return CalcRMS(
+            prbMol=mol_probe, refMol=mol_ref, symmetrizeConjugatedTerminalGroups=True, prbId=-1, refId=-1
+        )
+
     except RuntimeError:
         pass
     except ValueError:
@@ -23,91 +45,7 @@ def _call_rdkit_rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol, conf_id_probe: int, con
     return np.nan
 
 
-def _rmsd(
-    mol_probe: dm.Mol, mol_ref: dm.Mol, conf_id_probe: int, conf_id_ref: int, kabsch: bool = False, **params
-):
-    if kabsch is True:
-        return GetBestRMS(prbMol=mol_probe, refMol=mol_ref, prbId=conf_id_probe, refId=conf_id_ref, **params)
-    return CalcRMS(prbMol=mol_probe, refMol=mol_ref, prbId=conf_id_probe, refId=conf_id_ref, **params)
-
-
-def robust_rmsd(
-    mol_probe: dm.Mol,
-    mol_ref: dm.Mol,
-    conf_id_probe: int = -1,
-    conf_id_ref: int = -1,
-    drop_stereo: bool = False,
-    heavy_only: bool = True,
-    kabsch: bool = False,
-    symmetrizeConjugatedTerminalGroups=True,
-    **params,
-) -> float:
-    """RMSD calculation for isomers."""
-    mol_probe = deepcopy(mol_probe)
-    mol_ref = deepcopy(mol_ref)  # copy mols because rdkit RMSD calculation aligns mols
-
-    if drop_stereo:
-        mol_probe = dm.remove_stereochemistry(mol_probe)
-        mol_ref = dm.remove_stereochemistry(mol_ref)
-
-    if heavy_only:
-        mol_probe = dm.remove_hs(mol_probe)
-        mol_ref = dm.remove_hs(mol_ref)
-
-    # combine parameters
-    params = dict(
-        symmetrizeConjugatedTerminalGroups=symmetrizeConjugatedTerminalGroups, kabsch=kabsch, **params
-    )
-
-    # calculate RMSD
-    rmsd = _call_rdkit_rmsd(mol_probe, mol_ref, conf_id_probe, conf_id_ref, **params)
-    if not np.isnan(rmsd):
-        return rmsd
-
-    # try again but remove charges and hydrogens
-    mol_ref_uncharged = dm.to_neutral(dm.remove_hs(mol_ref))
-    mol_probe_uncharged = dm.to_neutral(dm.remove_hs(mol_probe))
-    rmsd = _call_rdkit_rmsd(mol_probe_uncharged, mol_ref_uncharged, conf_id_probe, conf_id_ref, **params)
-    if not np.isnan(rmsd):
-        return rmsd
-
-    # try again but neutralize atoms
-    mol_ref_neutralized = dm.to_neutral(mol_ref)
-    mol_probe_neutralized = dm.to_neutral(mol_probe)
-    rmsd = _call_rdkit_rmsd(mol_probe_neutralized, mol_ref_neutralized, conf_id_probe, conf_id_ref, **params)
-    if not np.isnan(rmsd):
-        return rmsd
-
-    # try again but on canonical tautomers
-    mol_ref_canonical = dm.canonical_tautomer(mol_ref)
-    mol_probe_canonical = dm.canonical_tautomer(mol_probe)
-    rmsd = _call_rdkit_rmsd(mol_probe_canonical, mol_ref_canonical, conf_id_probe, conf_id_ref, **params)
-    if not np.isnan(rmsd):
-        return rmsd
-
-    # try again but after neutralizing atoms
-    mol_ref_neutral_canonical = dm.canonical_tautomer(dm.to_neutral(mol_ref))
-    mol_probe_neutral_canonical = dm.canonical_tautomer(dm.to_neutral(mol_probe))
-    rmsd = _call_rdkit_rmsd(
-        mol_probe_neutral_canonical, mol_ref_neutral_canonical, conf_id_probe, conf_id_ref, **params
-    )
-    if not np.isnan(rmsd):
-        return rmsd
-
-    return np.nan
-
-
-def conformer_to_mol(mol, conf):
-    """conv"""
-    mol = dm.copy_mol(mol)
-    mol.RemoveAllConformers()
-    mol.AddConformer(conf, assignId=True)
-    return mol
-
-
-def rmsd_coverage(
-    y_pred: Union[str, List[dm.Mol]], y_true: Union[str, list[dm.Mol]], max_rsmd: float = 2, ignore_nan=False
-):
+def rmsd_coverage(y_pred: Union[str, List[dm.Mol]], y_true: Union[str, list[dm.Mol]], max_rsmd: float = 2):
     """
     Calculate the coverage of molecules with an RMSD less than 2 Å compared to the reference molecule conformer.
 
@@ -115,8 +53,6 @@ def rmsd_coverage(
         mols_probe: List of predicted binding conformers.
         mols_ref: List of ground truth binding confoermers.
         max_rsmd: The threshold for determining acceptable rsmd.
-        ignore_nan: Ignore conformers that failed to compute RMSD.
-
     """
 
     if len(y_pred) != len(y_true):
@@ -125,10 +61,7 @@ def rmsd_coverage(
         )
 
     rmsds = np.array(
-        [robust_rmsd(mol_probe=mol_probe, mol_ref=mol_ref) for mol_probe, mol_ref in zip(y_pred, y_true)]
+        [_rmsd(mol_probe=mol_probe, mol_ref=mol_ref) for mol_probe, mol_ref in zip(y_pred, y_true)]
     )
 
-    if ignore_nan:
-        rmsds = rmsds[~np.isnan(rmsds)]
-
-    return np.nansum(rmsds <= 2) * 100 / len(rmsds)
+    return np.nansum(rmsds <= max_rsmd) / len(rmsds)

--- a/polaris/evaluate/metrics/docking_metrics.py
+++ b/polaris/evaluate/metrics/docking_metrics.py
@@ -1,7 +1,6 @@
 # This script includes docking related evaluation metrics.
 
 from typing import Union, List
-from loguru import logger
 
 import numpy as np
 from rdkit.Chem.rdMolAlign import CalcRMS
@@ -32,19 +31,9 @@ def _rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol) -> float:
     mol_ref = dm.remove_hs(mol_ref)
 
     # calculate RMSD
-    try:
-        return CalcRMS(
-            prbMol=mol_probe, refMol=mol_ref, symmetrizeConjugatedTerminalGroups=True, prbId=-1, refId=-1
-        )
-
-    # Error when computing with CalcRMS
-    except RuntimeError:
-        pass
-    # Error when there are issue with probe molecule or reference molecule
-    except ValueError:
-        pass
-
-    return np.nan
+    return CalcRMS(
+        prbMol=mol_probe, refMol=mol_ref, symmetrizeConjugatedTerminalGroups=True, prbId=-1, refId=-1
+    )
 
 
 def rmsd_coverage(y_pred: Union[str, List[dm.Mol]], y_true: Union[str, list[dm.Mol]], max_rsmd: float = 2):
@@ -67,13 +56,5 @@ def rmsd_coverage(y_pred: Union[str, List[dm.Mol]], y_true: Union[str, list[dm.M
     rmsds = np.array(
         [_rmsd(mol_probe=mol_probe, mol_ref=mol_ref) for mol_probe, mol_ref in zip(y_pred, y_true)]
     )
-
-    nan_count = np.sum(np.isnan(rmsds))
-    if nan_count > 0:
-        logger.warning(
-            f"The rmsd results include {nan_count} nan values from the provided dataset. \
-        The converage value is calculated with these nan values, which may affect the accuracy of the results. ",
-            UserWarning,
-        )
-
-    return np.nansum(rmsds <= max_rsmd) / len(rmsds)
+    print(rmsds)
+    return np.sum(rmsds <= max_rsmd) / len(rmsds)

--- a/polaris/evaluate/metrics/docking_metrics.py
+++ b/polaris/evaluate/metrics/docking_metrics.py
@@ -37,8 +37,10 @@ def _rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol) -> float:
             prbMol=mol_probe, refMol=mol_ref, symmetrizeConjugatedTerminalGroups=True, prbId=-1, refId=-1
         )
 
+    # This can happen if ...
     except RuntimeError:
         pass
+    # This can happen if ...
     except ValueError:
         pass
 

--- a/polaris/evaluate/metrics/docking_metrics.py
+++ b/polaris/evaluate/metrics/docking_metrics.py
@@ -1,0 +1,134 @@
+# This script includes docking related evaluation metrics.
+
+from typing import Union, List
+from copy import deepcopy
+
+import numpy as np
+from rdkit.Chem.rdMolAlign import CalcRMS, GetBestRMS
+
+import datamol as dm
+
+
+## The following rmsd implementation are modified based on ppsebusters https://github.com/maabuu/posebusters/blob/main/posebusters/modules/rmsd.py
+
+
+def _call_rdkit_rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol, conf_id_probe: int, conf_id_ref: int, **params):
+    try:
+        return _rmsd(mol_probe, mol_ref, conf_id_probe, conf_id_ref, **params)
+    except RuntimeError:
+        pass
+    except ValueError:
+        pass
+
+    return np.nan
+
+
+def _rmsd(
+    mol_probe: dm.Mol, mol_ref: dm.Mol, conf_id_probe: int, conf_id_ref: int, kabsch: bool = False, **params
+):
+    if kabsch is True:
+        return GetBestRMS(prbMol=mol_probe, refMol=mol_ref, prbId=conf_id_probe, refId=conf_id_ref, **params)
+    return CalcRMS(prbMol=mol_probe, refMol=mol_ref, prbId=conf_id_probe, refId=conf_id_ref, **params)
+
+
+def robust_rmsd(
+    mol_probe: dm.Mol,
+    mol_ref: dm.Mol,
+    conf_id_probe: int = -1,
+    conf_id_ref: int = -1,
+    drop_stereo: bool = False,
+    heavy_only: bool = True,
+    kabsch: bool = False,
+    symmetrizeConjugatedTerminalGroups=True,
+    **params,
+) -> float:
+    """RMSD calculation for isomers."""
+    mol_probe = deepcopy(mol_probe)
+    mol_ref = deepcopy(mol_ref)  # copy mols because rdkit RMSD calculation aligns mols
+
+    if drop_stereo:
+        mol_probe = dm.remove_stereochemistry(mol_probe)
+        mol_ref = dm.remove_stereochemistry(mol_ref)
+
+    if heavy_only:
+        mol_probe = dm.remove_hs(mol_probe)
+        mol_ref = dm.remove_hs(mol_ref)
+
+    # combine parameters
+    params = dict(
+        symmetrizeConjugatedTerminalGroups=symmetrizeConjugatedTerminalGroups, kabsch=kabsch, **params
+    )
+
+    # calculate RMSD
+    rmsd = _call_rdkit_rmsd(mol_probe, mol_ref, conf_id_probe, conf_id_ref, **params)
+    if not np.isnan(rmsd):
+        return rmsd
+
+    # try again but remove charges and hydrogens
+    mol_ref_uncharged = dm.to_neutral(dm.remove_hs(mol_ref))
+    mol_probe_uncharged = dm.to_neutral(dm.remove_hs(mol_probe))
+    rmsd = _call_rdkit_rmsd(mol_probe_uncharged, mol_ref_uncharged, conf_id_probe, conf_id_ref, **params)
+    if not np.isnan(rmsd):
+        return rmsd
+
+    # try again but neutralize atoms
+    mol_ref_neutralized = dm.to_neutral(mol_ref)
+    mol_probe_neutralized = dm.to_neutral(mol_probe)
+    rmsd = _call_rdkit_rmsd(mol_probe_neutralized, mol_ref_neutralized, conf_id_probe, conf_id_ref, **params)
+    if not np.isnan(rmsd):
+        return rmsd
+
+    # try again but on canonical tautomers
+    mol_ref_canonical = dm.canonical_tautomer(mol_ref)
+    mol_probe_canonical = dm.canonical_tautomer(mol_probe)
+    rmsd = _call_rdkit_rmsd(mol_probe_canonical, mol_ref_canonical, conf_id_probe, conf_id_ref, **params)
+    if not np.isnan(rmsd):
+        return rmsd
+
+    # try again but after neutralizing atoms
+    mol_ref_neutral_canonical = dm.canonical_tautomer(dm.to_neutral(mol_ref))
+    mol_probe_neutral_canonical = dm.canonical_tautomer(dm.to_neutral(mol_probe))
+    rmsd = _call_rdkit_rmsd(
+        mol_probe_neutral_canonical, mol_ref_neutral_canonical, conf_id_probe, conf_id_ref, **params
+    )
+    if not np.isnan(rmsd):
+        return rmsd
+
+    return np.nan
+
+
+def conformer_to_mol(mol, conf):
+    """conv"""
+    mol = dm.copy_mol(mol)
+    mol.RemoveAllConformers()
+    mol.AddConformer(conf, assignId=True)
+    return mol
+
+
+def rmsd_coverage(
+    y_pred: Union[str, List[dm.Mol]], y_true: Union[str, list[dm.Mol]], max_rsmd: float = 2, ignore_nan=False
+):
+    """
+    Calculate the coverage of molecules with an RMSD less than 2 Å compared to the reference molecule conformer.
+
+    Attributes:
+        mols_probe: List of predicted binding conformers.
+        mols_ref: List of ground truth binding confoermers.
+        max_rsmd: The threshold for determining acceptable rsmd.
+        ignore_nan: Ignore conformers that failed to compute RMSD.
+
+    """
+
+    if len(y_pred) != len(y_true):
+        assert ValueError(
+            f"The list of probing molecules and the list of reference molecules are different sizes. {len(y_pred)} != {len(y_true)} "
+        )
+
+    rmsds = np.array(
+        [robust_rmsd(mol_probe=mol_probe, mol_ref=mol_ref) for mol_probe, mol_ref in zip(y_pred, y_true)]
+    )
+
+    if ignore_nan:
+        rmsds = rmsds[~np.isnan(rmsds)]
+
+    return np.nansum(rmsds <= 2) * 100 / len(rmsds)

--- a/polaris/evaluate/metrics/generic_metrics.py
+++ b/polaris/evaluate/metrics/generic_metrics.py
@@ -1,0 +1,42 @@
+import numpy as np
+from scipy import stats
+from sklearn.metrics import cohen_kappa_score as sk_cohen_kappa_score
+
+
+def pearsonr(y_true: np.ndarray, y_pred: np.ndarray):
+    """Calculate a pearson r correlation"""
+    return stats.pearsonr(y_true, y_pred).statistic
+
+
+def spearman(y_true: np.ndarray, y_pred: np.ndarray):
+    """Calculate a Spearman correlation"""
+    return stats.spearmanr(y_true, y_pred).statistic
+
+
+def absolute_average_fold_error(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """
+    Calculate the Absolute Average Fold Error (AAFE) metric.
+    It measures the fold change between predicted values and observed values.
+    The implementation is based on [this paper](https://pubs.acs.org/doi/10.1021/acs.chemrestox.3c00305).
+
+    Args:
+        y_true: The true target values of shape (n_samples,)
+        y_pred: The predicted target values of shape (n_samples,).
+
+    Returns:
+        aafe: The Absolute Average Fold Error.
+    """
+    if len(y_true) != len(y_pred):
+        raise ValueError("Length of y_true and y_pred must be the same.")
+
+    if np.any(y_true == 0):
+        raise ValueError("`y_true` contains zero which will result `Inf` value.")
+
+    aafe = np.mean(np.abs(y_pred) / np.abs(y_true))
+
+    return aafe
+
+
+def cohen_kappa_score(y_true, y_pred, **kwargs):
+    """Scikit learn cohen_kappa_score wraper with renamed arguments"""
+    return sk_cohen_kappa_score(y1=y_true, y2=y_pred, **kwargs)

--- a/polaris/evaluate/utils.py
+++ b/polaris/evaluate/utils.py
@@ -42,6 +42,21 @@ def safe_mask(
         return input_values[test_label][target_label][mask]
 
 
+def mask_index(input_values):
+    if np.issubdtype(input_values.dtype, np.number):
+        mask = ~np.isnan(input_values)
+    else:
+        # Create a mask to identify NaNs
+        mask = np.full(input_values.shape, True, dtype=bool)
+        print(mask.shape)
+        # Iterate over the array to identify NaNs
+        for index, value in np.ndenumerate(input_values):
+            # Convert to float and check if it's NaN
+            if value is None:
+                mask[index] = False
+    return mask
+
+
 def evaluate_benchmark(
     target_cols: list[str],
     metrics: list[Metric],
@@ -84,7 +99,9 @@ def evaluate_benchmark(
             for target_label, y_true_target in y_true_subset.items():
                 # Single-task metrics for a multi-task benchmark
                 # In such a setting, there can be NaN values, which we thus have to filter out.
-                mask = ~np.isnan(y_true_target)
+
+                mask = mask_index(y_true_target)
+
                 score = metric(
                     y_true=y_true_target[mask],
                     y_pred=safe_mask(y_pred, test_label, target_label, mask),

--- a/polaris/evaluate/utils.py
+++ b/polaris/evaluate/utils.py
@@ -48,7 +48,6 @@ def mask_index(input_values):
     else:
         # Create a mask to identify NaNs
         mask = np.full(input_values.shape, True, dtype=bool)
-        print(mask.shape)
         # Iterate over the array to identify NaNs
         for index, value in np.ndenumerate(input_values):
             # Convert to float and check if it's NaN

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -162,6 +162,7 @@ class TargetType(Enum):
 
     REGRESSION = "regression"
     CLASSIFICATION = "classification"
+    DOCKING = "docking"
 
 
 class TaskType(Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,11 +30,6 @@ def test_data():
     data["CLASS_calc"] = data["calc"].gt(0).astype(int).values
     data["MULTICLASS_expt"] = np.random.randint(low=0, high=3, size=data.shape[0])
     data["MULTICLASS_calc"] = np.random.randint(low=0, high=3, size=data.shape[0])
-    # docking related
-    mols = data["smiles"].apply(dm.to_mol)
-    data["conformer_ref"] = np.array(
-        [conformer_to_mol(mol, dm.conformers.generate(mol).GetConformer(0)) for mol in mols]
-    )
     return data
 
 
@@ -116,6 +111,28 @@ def test_user_owner():
 
 @pytest.fixture(scope="function")
 def test_dataset(test_data, test_org_owner) -> DatasetV1:
+    dataset = DatasetV1(
+        table=test_data,
+        name="test-dataset",
+        source="https://www.example.com",
+        annotations={"expt": ColumnAnnotation(user_attributes={"unit": "kcal/mol"})},
+        tags=["tagA", "tagB"],
+        user_attributes={"attributeA": "valueA", "attributeB": "valueB"},
+        owner=test_org_owner,
+        license="CC-BY-4.0",
+        curation_reference="https://www.example.com",
+    )
+    check_version(dataset)
+    return dataset
+
+
+@pytest.fixture(scope="function")
+def test_docking_dataset(test_data, test_org_owner) -> DatasetV1:
+    # docking related
+    mols = test_data["smiles"].apply(dm.to_mol)
+    test_data["conformer_ref"] = np.array(
+        [conformer_to_mol(mol, dm.conformers.generate(mol).GetConformer(0)) for mol in mols]
+    )
     dataset = DatasetV1(
         table=test_data,
         name="test-dataset",
@@ -390,10 +407,10 @@ def test_multi_task_benchmark_multiple_test_sets(test_dataset):
 
 
 @pytest.fixture(scope="function")
-def test_docking_benchmark(test_dataset):
+def test_docking_benchmark(test_docking_dataset):
     benchmark = SingleTaskBenchmarkSpecification(
         name="single-task-single-set-benchmark",
-        dataset=test_dataset,
+        dataset=test_docking_dataset,
         metrics=["rmsd_coverage"],
         split=([], list(range(100))),
         target_cols=["conformer_ref"],

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -191,7 +191,15 @@ def test_metrics_docking(test_docking_benchmark: SingleTaskBenchmarkSpecificatio
     _, test = test_docking_benchmark.get_train_test_split()
 
     predictions = np.array([caffeine, ibuprofen])
-
     result = test_docking_benchmark.evaluate(y_pred=predictions)
+
     for metric in test_docking_benchmark.metrics:
         assert metric in result.results.Metric.tolist()
+
+    # sanity check
+    assert result.results.Score.values[0] == 1
+
+    predictions = np.array([ibuprofen, caffeine])
+    result = test_docking_benchmark.evaluate(y_pred=predictions)
+    # sanity check
+    assert result.results.Score.values[0] == 0

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import datamol as dm
+
 import polaris as po
 from polaris.benchmark import (
     MultiTaskBenchmarkSpecification,
@@ -199,7 +201,8 @@ def test_metrics_docking(test_docking_benchmark: SingleTaskBenchmarkSpecificatio
     # sanity check
     assert result.results.Score.values[0] == 1
 
-    predictions = np.array([ibuprofen, caffeine])
+    conf_caffeine = dm.conformers.generate(mol=caffeine, n_confs=1, random_seed=333)
+    conf_ibuprofen = dm.conformers.generate(mol=ibuprofen, n_confs=1, random_seed=333)
+    predictions = np.array([conf_caffeine, conf_ibuprofen])
     result = test_docking_benchmark.evaluate(y_pred=predictions)
-    # sanity check
     assert result.results.Score.values[0] == 0

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import datamol as dm
 import polaris as po
 from polaris.benchmark import (
     MultiTaskBenchmarkSpecification,
@@ -14,7 +13,6 @@ from polaris.dataset import DatasetV1
 from polaris.evaluate._metric import Metric
 from polaris.evaluate._results import BenchmarkResults
 from polaris.utils.types import HubOwner
-from polaris.evaluate.metrics.docking_metrics import conformer_to_mol
 
 
 def test_result_to_json(tmpdir: str, test_user_owner: HubOwner):
@@ -189,15 +187,10 @@ def test_metric_y_types(
     assert result.results.Score.values[0] == Metric.f1.fn(y_true=test_y, y_pred=predictions)
 
 
-def test_metrics_docking(
-    test_docking_benchmark: SingleTaskBenchmarkSpecification,
-):
+def test_metrics_docking(test_docking_benchmark: SingleTaskBenchmarkSpecification, caffeine, ibuprofen):
     _, test = test_docking_benchmark.get_train_test_split()
 
-    mols = [dm.to_mol(mol) for mol in test.inputs]
-    predictions = np.array(
-        [conformer_to_mol(mol, dm.conformers.generate(mol).GetConformer(1)) for mol in mols]
-    )
+    predictions = np.array([caffeine, ibuprofen])
 
     result = test_docking_benchmark.evaluate(y_pred=predictions)
     for metric in test_docking_benchmark.metrics:


### PR DESCRIPTION
## Changelogs

- Added metric `rmsd_coverage` for docking related benchmarks
- Added unit tests
- Added new target type "docking"

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---
The rmsd metrics are implemented based on the [Posebuster codebase](https://github.com/maabuu/posebusters/blob/main/posebusters/modules/rmsd.py). A few modifications were made, replacing RDKit callables with equivalent Datamol functions. The RMSD calculation was also simplified to evaluate only the first conformer of the predicted molecule and to consider only heavy atoms.

Note: Posebusters provides a series of checkers, known as '[Posebuster Checkers](https://github.com/maabuu/posebusters/tree/main),' to further filter out unwanted docked ligand conformers. To avoid over-complicating Polaris metrics module with case-specific metrics, users should apply these filters before uploading results to the Polaris hub.