### PR TITLE
Fix the cases of the Content Type keys 

### DIFF
--- a/polaris/dataset/_column.py
+++ b/polaris/dataset/_column.py
@@ -21,8 +21,8 @@ class Modality(enum.Enum):
 class KnownContentType(enum.Enum):
     """Used to specify column's IANA content type in a dataset."""
 
-    SMILES = "chemical/x-smiles"
-    PDB = "chemical/x-pdb"
+    SMILES = "CHEMICAL/X-SMILES"
+    PDB = "CHEMICAL/X-PBD"
 
 
 class ColumnAnnotation(BaseModel):


### PR DESCRIPTION
## Changelogs

The keys for known content types is being converted into uppercase in the validator, but they are stored in lowercase. This PR changes the key into uppercase to match the validator's expectation.
