### PR TITLE
feat: deterministic Zarr checksum

### DIFF
--- a/polaris/dataset/zarr/_manifest.py
+++ b/polaris/dataset/zarr/_manifest.py
@@ -38,6 +38,7 @@ def deterministic_walk(root_path: str):
         for file_name in sorted(file_names):
             yield os.path.join(dir_path, file_name)
 
+
 def recursively_build_manifest(dir_path: str, writer: pq.ParquetWriter, zarr_root_path: str) -> str:
     """
     Recursive function that traverses a Zarr archive to build a V2 manifest file.
@@ -52,7 +53,6 @@ def recursively_build_manifest(dir_path: str, writer: pq.ParquetWriter, zarr_roo
     #
     # Loop through directory items in iterator
     for entry in deterministic_walk(dir_path):
-        
         if os.path.isdir(entry):
             # If item is a directory, recurse into that directory
             recursively_build_manifest(entry, writer, zarr_root_path)

--- a/polaris/dataset/zarr/_manifest.py
+++ b/polaris/dataset/zarr/_manifest.py
@@ -33,7 +33,8 @@ def deterministic_walk(root_path: str):
         root_path: The path to the root of the directory to walk
     """
 
-    for dir_path, _, file_names in os.walk(root_path):
+    for dir_path, dirs, file_names in os.walk(root_path):
+        dirs.sort()
         for file_name in sorted(file_names):
             yield os.path.join(dir_path, file_name)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,6 @@ def test_dataset(test_data, test_org_owner) -> DatasetV1:
     return dataset
 
 
-
 @pytest.fixture(scope="function")
 def test_dataset_v2(zarr_archive, test_org_owner) -> DatasetV2:
     dataset = DatasetV2(
@@ -143,7 +142,6 @@ def test_dataset_v2(zarr_archive, test_org_owner) -> DatasetV2:
     )
     check_version(dataset)
     return dataset
-
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,7 @@ def test_dataset(test_data, test_org_owner) -> DatasetV1:
     return dataset
 
 
+
 @pytest.fixture(scope="function")
 def test_dataset_v2(zarr_archive, test_org_owner) -> DatasetV2:
     dataset = DatasetV2(
@@ -142,6 +143,7 @@ def test_dataset_v2(zarr_archive, test_org_owner) -> DatasetV2:
     )
     check_version(dataset)
     return dataset
+
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_dataset_v2.py
+++ b/tests/test_dataset_v2.py
@@ -272,6 +272,10 @@ def test_zarr_manifest_deterministic(test_dataset_v2, test_org_owner, zarr_archi
     )
     assert new_md5sum == dataset.zarr_manifest_md5sum
 
+    # check all the files are in there
+    df = pd.read_parquet(dataset.zarr_manifest_path)
+    assert len(df) == 204
+
 
 
 

--- a/tests/test_dataset_v2.py
+++ b/tests/test_dataset_v2.py
@@ -293,5 +293,3 @@ def test_dataset_v2__get_item__(test_dataset_v2, zarr_archive):
 
     _check_row_equality(test_dataset_v2[0], {"A": root["A"][0, :], "B": root["B"][0, :]})
     _check_row_equality(test_dataset_v2[10], {"A": root["A"][10, :], "B": root["B"][10, :]})
-
-

--- a/tests/test_dataset_v2.py
+++ b/tests/test_dataset_v2.py
@@ -252,6 +252,18 @@ def test_zarr_manifest(test_dataset_v2):
     assert post_change_manifest_length == 305
 
 
+
+def test_zarr_manifest_deterministic(test_dataset_v2):
+    # try creating and comparing two manifest files
+    # created from the same Zarr archive
+    generate_zarr_manifest(test_dataset_v2.zarr_root_path, test_dataset_v2._cache_dir)
+    md5sum = test_dataset_v2.zarr_manifest_md5sum
+    generate_zarr_manifest(test_dataset_v2.zarr_root_path, test_dataset_v2._cache_dir)
+    assert md5sum == test_dataset_v2.zarr_manifest_md5sum
+
+
+
+
 def test_dataset_v2__get_item__(test_dataset_v2, zarr_archive):
     """Test the __getitem__() interface for the dataset V2."""
 
@@ -269,3 +281,5 @@ def test_dataset_v2__get_item__(test_dataset_v2, zarr_archive):
 
     _check_row_equality(test_dataset_v2[0], {"A": root["A"][0, :], "B": root["B"][0, :]})
     _check_row_equality(test_dataset_v2[10], {"A": root["A"][10, :], "B": root["B"][10, :]})
+
+

--- a/tests/test_dataset_v2.py
+++ b/tests/test_dataset_v2.py
@@ -256,10 +256,20 @@ def test_zarr_manifest(test_dataset_v2):
 def test_zarr_manifest_deterministic(test_dataset_v2):
     # try creating and comparing two manifest files
     # created from the same Zarr archive
+    initial_md5sum = test_dataset_v2.zarr_manifest_md5sum
     generate_zarr_manifest(test_dataset_v2.zarr_root_path, test_dataset_v2._cache_dir)
-    md5sum = test_dataset_v2.zarr_manifest_md5sum
+    df = pd.read_parquet(test_dataset_v2.zarr_manifest_path)
+
+    print(df)
+    new_md5sum = test_dataset_v2.zarr_manifest_md5sum
+    assert initial_md5sum == new_md5sum
+    df = pd.read_parquet(test_dataset_v2.zarr_manifest_path)
+    print(df)
     generate_zarr_manifest(test_dataset_v2.zarr_root_path, test_dataset_v2._cache_dir)
-    assert md5sum == test_dataset_v2.zarr_manifest_md5sum
+    assert new_md5sum == test_dataset_v2.zarr_manifest_md5sum
+    df = pd.read_parquet(test_dataset_v2.zarr_manifest_path)
+    print(df)
+    raise Exception("stop here")
 
 
 

--- a/tests/test_dataset_v2.py
+++ b/tests/test_dataset_v2.py
@@ -252,7 +252,6 @@ def test_zarr_manifest(test_dataset_v2):
     assert post_change_manifest_length == 305
 
 
-
 def test_zarr_manifest_deterministic(test_dataset_v2, test_org_owner, zarr_archive):
     # try creating and comparing two manifest files
     initial_md5sum = test_dataset_v2.zarr_manifest_md5sum
@@ -275,8 +274,6 @@ def test_zarr_manifest_deterministic(test_dataset_v2, test_org_owner, zarr_archi
     # check all the files are in there
     df = pd.read_parquet(dataset.zarr_manifest_path)
     assert len(df) == 204
-
-
 
 
 def test_dataset_v2__get_item__(test_dataset_v2, zarr_archive):


### PR DESCRIPTION
## Changelogs

* Sort the directories of the dataset before they are walked by `recursively_build_manifest` to yield deterministic ordering of the Zarr manifest file and corresponding MD5 checksum. 
* Add test for recreating manifest file multiple times, checking its checksum

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [X] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

Fixes #188 

* This should (hopefully) take care of file ordering  messing up checksums for `zarr` manifests. 

* A specific case where you have encountered non-determinism may be helpful, as I struggled to generate a failing counterexample on `main`. 



