### PR TITLE
chore: Update dataset manifest build

### DIFF
--- a/polaris/dataset/zarr/_manifest.py
+++ b/polaris/dataset/zarr/_manifest.py
@@ -8,7 +8,8 @@ from pyarrow.parquet import write_table
 # PyArrow table schema for the V2 Zarr manifest file
 ZARR_MANIFEST_SCHEMA = schema([("path", string()), ("md5_checksum", string())])
 
-ROW_GROUP_SIZE = 128 * 1024 * 1024 # 128 MB
+ROW_GROUP_SIZE = 128 * 1024 * 1024  # 128 MB
+
 
 def generate_zarr_manifest(zarr_root_path: str, output_dir: str) -> str:
     """

--- a/polaris/dataset/zarr/_manifest.py
+++ b/polaris/dataset/zarr/_manifest.py
@@ -1,11 +1,12 @@
 import os
 from hashlib import md5
+from pathlib import Path
 
-import pyarrow as pa
-import pyarrow.parquet as pq
+from pyarrow import Table, schema, string
+from pyarrow.parquet import write_table
 
 # PyArrow table schema for the V2 Zarr manifest file
-ZARR_MANIFEST_SCHEMA = pa.schema([("path", pa.string()), ("md5_checksum", pa.string())])
+ZARR_MANIFEST_SCHEMA = schema([("path", string()), ("md5_checksum", string())])
 
 
 def generate_zarr_manifest(zarr_root_path: str, output_dir: str) -> str:
@@ -16,46 +17,37 @@ def generate_zarr_manifest(zarr_root_path: str, output_dir: str) -> str:
         zarr_root_path: The path to the root of a Zarr archive
         output_dir: The path to the directory which will hold the generated manifest
     """
-
     zarr_manifest_path = f"{output_dir}/zarr_manifest.parquet"
 
-    with pq.ParquetWriter(zarr_manifest_path, ZARR_MANIFEST_SCHEMA) as writer:
-        recursively_build_manifest(zarr_root_path, writer, zarr_root_path)
+    entries = manifest_entries(zarr_root_path, zarr_root_path)
+    manifest = Table.from_pylist(mapping=entries, schema=ZARR_MANIFEST_SCHEMA)
+    write_table(manifest, zarr_manifest_path)
 
     return zarr_manifest_path
 
 
-def recursively_build_manifest(dir_path: str, writer: pq.ParquetWriter, zarr_root_path: str) -> None:
+def manifest_entries(dir_path: str, root_path: str) -> list[dict[str, str]]:
     """
-    Recursive function that traverses a Zarr archive to build a V2 manifest file.
+    Recursive function that traverses a directory, returning entries consisting of every file's path and MD5 hash
 
     Parameters:
-        dir_path: The path to the current directory being processed in the archive
-        writer: Writer object for incrementally adding rows to the manifest Parquet file
-        zarr_root_path: The root path which triggered the first recursive call
+        dir_path: The path to the current directory being traversed
+        root_path: The root path from which to compute a relative path
     """
-
-    # Get iterator of items located in the directory at `dir_path`
+    entries = []
     with os.scandir(dir_path) as it:
-        #
-        # Loop through directory items in iterator
         for entry in it:
-            if entry.is_dir():
-                #
-                # If item is a directory, recurse into that directory
-                recursively_build_manifest(entry.path, writer, zarr_root_path)
-            elif entry.is_file():
-                #
-                # If item is a file, calculate its relative path and chunk checksum. Then, append that
-                # to the Zarr manifest parquet.
-                table = pa.Table.from_pydict(
+            if entry.is_file():
+                entries.append(
                     {
-                        "path": [os.path.relpath(entry.path, zarr_root_path)],
-                        "md5_checksum": [calculate_file_md5(entry.path)],
-                    },
-                    schema=ZARR_MANIFEST_SCHEMA,
+                        "path": str(Path(entry.path).relative_to(root_path)),
+                        "md5_checksum": calculate_file_md5(entry.path),
+                    }
                 )
-                writer.write_table(table)
+            elif entry.is_dir():
+                entries.extend(manifest_entries(entry.path, root_path))
+
+    return entries
 
 
 def calculate_file_md5(file_path: str) -> str:

--- a/polaris/dataset/zarr/_manifest.py
+++ b/polaris/dataset/zarr/_manifest.py
@@ -8,6 +8,7 @@ from pyarrow.parquet import write_table
 # PyArrow table schema for the V2 Zarr manifest file
 ZARR_MANIFEST_SCHEMA = schema([("path", string()), ("md5_checksum", string())])
 
+ROW_GROUP_SIZE = 128 * 1024 * 1024 # 128 MB
 
 def generate_zarr_manifest(zarr_root_path: str, output_dir: str) -> str:
     """
@@ -21,7 +22,7 @@ def generate_zarr_manifest(zarr_root_path: str, output_dir: str) -> str:
 
     entries = manifest_entries(zarr_root_path, zarr_root_path)
     manifest = Table.from_pylist(mapping=entries, schema=ZARR_MANIFEST_SCHEMA)
-    write_table(manifest, zarr_manifest_path)
+    write_table(manifest, zarr_manifest_path, row_group_size=ROW_GROUP_SIZE)
 
     return zarr_manifest_path
 


### PR DESCRIPTION
## Changelogs

- Update the way we build the Zarr archive manifest to use a single PyArrow table. This yields a reduction of ~90% in size of the resulting manifest, probably due to better compression. (A manifest of 3708 files went from 2.7MB to 119KB.)

---

_Checklist:_

- ~[ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- ~[ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- ~[ ] _Update the API documentation if a new function is added, or an existing one is deleted._~
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
