### PR TITLE
Feature: Download for V2 datasets

### DIFF
--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -132,6 +132,17 @@ class DatasetV1(BaseDataset, ChecksumMixin):
         checksum = hash_fn.hexdigest()
         return checksum
 
+    def load_zarr_root_from_hub(self):
+        """
+        Loads a Zarr archive from the Hub.
+        """
+        from polaris.hub.client import PolarisHubClient
+        from polaris.hub.storage import StorageSession
+
+        with PolarisHubClient() as client:
+            with StorageSession(client, "read", self.urn) as storage:
+                return zarr.open_consolidated(store=storage.extension_store)
+
     @computed_field
     @property
     def zarr_md5sum_manifest(self) -> List[ZarrFileChecksum]:
@@ -311,7 +322,7 @@ class DatasetV1(BaseDataset, ChecksumMixin):
 
     def _repr_dict_(self) -> dict:
         """Utility function for pretty-printing to the command line and jupyter notebooks"""
-        repr_dict = self.model_dump(exclude={"table", "zarr_md5sum_manifest"})
+        repr_dict = self.model_dump(exclude={"table", "zarr_md5sum_manifest", "md5sum"})
         return repr_dict
 
     def __eq__(self, other):

--- a/polaris/experimental/_dataset_v2.py
+++ b/polaris/experimental/_dataset_v2.py
@@ -113,6 +113,17 @@ class DatasetV2(BaseDataset):
             dtypes[group] = np.dtype(object)
         return dtypes
 
+    def load_zarr_root_from_hub(self):
+        """
+        Loads a Zarr archive from the Hub.
+        """
+        from polaris.hub.client import PolarisHubClient
+        from polaris.hub.storage import StorageSession
+
+        with PolarisHubClient() as client:
+            with StorageSession(client, "read", self.urn) as storage:
+                return zarr.open_consolidated(store=storage.root_store)
+
     @property
     def zarr_manifest_path(self) -> str:
         if self._zarr_manifest_path is None:
@@ -263,7 +274,7 @@ class DatasetV2(BaseDataset):
 
     def _repr_dict_(self) -> dict:
         """Utility function for pretty-printing to the command line and jupyter notebooks"""
-        repr_dict = self.model_dump()
+        repr_dict = self.model_dump(exclude={"zarr_manifest_path", "zarr_manifest_md5sum"})
         return repr_dict
 
     def should_verify_checksum(self, strategy: ChecksumStrategy) -> bool:

--- a/polaris/hub/external_client.py
+++ b/polaris/hub/external_client.py
@@ -78,6 +78,11 @@ class ExternalAuthClient(OAuth2Client):
             ) from error
 
     def ensure_active_token(self, token: OAuth2Token | None = None) -> bool:
+        if token is None:
+            # This won't be needed with if we set a lower bound for authlib: >=1.3.2
+            # See https://github.com/lepture/authlib/pull/625
+            # As of now, this latest version is not available on Conda though.
+            token = self.token
         try:
             return super().ensure_active_token(token) or False
         except OAuthError:


### PR DESCRIPTION
## Changelogs

- Added support for downloading V2 Datasets from the Hub.
- Given that `authlib >1.3.0` is [not yet available for Conda](https://github.com/conda-forge/authlib-feedstock), we can't assume a [recently merged QoL improvement](https://github.com/lepture/authlib/commit/16fa567110b4bb4094f3ab3a452bafb9945847fb) is available and needed some code to handle the case that `token` is None in `ensure_active_token()`.
- Excluded some fields from the `repr_dict` to prevent excessive compute when visualizing the dataset.

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

The `client.get_dataset()` tries loading a V1 dataset first, and then the V2 if a 404 is raised. This adds some overhead, but given the deadline I would like us to optimize this later. 

### A word on testing

We don't have a great way setup yet to test these changes, so I manually created three datasets on the `cas` Neon branch: 

1. A vanilla V1 dataset
2. A V1 dataset with pointer columns
3. A V2 dataset

All three of these datasets are public, so as long as you use my Neon branch you should be able to replicate the tests I've done using this code:
```python
with PolarisHubClient(settings=settings) as client:
    # V2 dataset
    dataset = client.get_dataset(owner="casw3", name="BELKA-v5")
    print(dataset[123456])

    # V1 dataset with pointers
    dataset = client.get_dataset(owner="casw3", name="v1-with-pointers-2")
    print(dataset[0])

    # Vanilla V1 dataset
    dataset = client.get_dataset(owner="casw3", name="biogen-adme-v1")
    print(dataset[123])
```

This also works:
```py
for name in ["BELKA-v5", "v1-with-pointers-2", "biogen-adme-v1"]:
    po.load_dataset(f"casw3/{name}")
```