### PR TITLE
Fix: Exclude some computed properties during caching

### DIFF
--- a/polaris/experimental/_dataset_v2.py
+++ b/polaris/experimental/_dataset_v2.py
@@ -238,7 +238,9 @@ class DatasetV2(BaseDataset):
         new_zarr_root_path = str(destination / "data.zarr")
 
         # Lu: Avoid serializing and sending None to hub app.
-        serialized = self.model_dump(exclude_none=True)
+        serialized = self.model_dump(
+            exclude_none=True, exclude={"zarr_manifest_path", "zarr_manifest_md5sum"}
+        )
         serialized["zarrRootPath"] = new_zarr_root_path
 
         # Copy over Zarr data to the destination


### PR DESCRIPTION
## Changelogs

- Computing the zarr checksum manifest properties during caching would fail. We thus exclude these properties from the `model_dump()`
