### PR TITLE
Chore: Add `imagecodecs` as an optional dependency

### DIFF
--- a/polaris/__init__.py
+++ b/polaris/__init__.py
@@ -4,7 +4,16 @@ import sys
 from loguru import logger
 
 from ._version import __version__
-from .loader import load_benchmark, load_dataset, load_competition
+from .loader import load_benchmark, load_competition, load_dataset
+
+try:
+    # Register imagecodecs if they are available.
+    from imagecodecs.numcodecs import register_codecs
+
+    register_codecs()
+except ImportError:
+    pass
+
 
 __all__ = ["load_dataset", "load_benchmark", "__version__", "load_competition"]
 

--- a/polaris/__init__.py
+++ b/polaris/__init__.py
@@ -6,15 +6,6 @@ from loguru import logger
 from ._version import __version__
 from .loader import load_benchmark, load_competition, load_dataset
 
-try:
-    # Register imagecodecs if they are available.
-    from imagecodecs.numcodecs import register_codecs
-
-    register_codecs()
-except ImportError:
-    pass
-
-
 __all__ = ["load_dataset", "load_benchmark", "__version__", "load_competition"]
 
 # Configure the default logging level

--- a/polaris/dataset/_base.py
+++ b/polaris/dataset/_base.py
@@ -22,7 +22,7 @@ from polaris._artifact import BaseArtifactModel
 from polaris.dataset._adapters import Adapter
 from polaris.dataset._column import ColumnAnnotation
 from polaris.dataset.zarr import MemoryMappedDirectoryStore
-from polaris.dataset.zarr._utils import load_zarr_group_to_memory
+from polaris.dataset.zarr._utils import check_zarr_codecs, load_zarr_group_to_memory
 from polaris.utils.constants import DEFAULT_CACHE_DIR
 from polaris.utils.dict2html import dict2html
 from polaris.utils.errors import InvalidDatasetError
@@ -193,6 +193,8 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
             raise InvalidDatasetError(
                 "A Zarr archive associated with a Polaris dataset has to be consolidated."
             ) from error
+
+        check_zarr_codecs(self._zarr_root)
         return self._zarr_root
 
     @abc.abstractmethod

--- a/polaris/dataset/zarr/_utils.py
+++ b/polaris/dataset/zarr/_utils.py
@@ -40,5 +40,5 @@ def check_zarr_codecs(group: zarr.Group):
             raise error
 
         # Remove prefix and apostrophes
-        codec_id = error_message.removeprefix(prefix)[1:-1]
+        codec_id = error_message.removeprefix(prefix).strip("'")
         raise InvalidZarrCodec(codec_id)

--- a/polaris/dataset/zarr/_utils.py
+++ b/polaris/dataset/zarr/_utils.py
@@ -11,3 +11,22 @@ def load_zarr_group_to_memory(group: zarr.Group) -> dict:
         elif isinstance(item, zarr.Group):
             data[key] = load_zarr_group_to_memory(item)
     return data
+
+
+def check_zarr_codecs(group: zarr.Group):
+    """Check if all codecs in the Zarr group are registered."""
+    try:
+        for key, item in group.items():
+            if isinstance(item, zarr.Group):
+                check_zarr_codecs(item)
+    except ValueError as error:
+        # Zarr raises a generic ValueError if a codec is not registered.
+        # See also: https://github.com/zarr-developers/zarr-python/issues/2508
+        prefix = "codec not available: "
+        message = str(error)
+        codec_id = message.removeprefix(prefix)
+
+        if message.startswith(prefix):
+            raise RuntimeError(
+                f"This Zarr archive requires the {codec_id} codec. Install all optional codecs with 'pip install polaris-lib[codecs]'."
+            ) from error

--- a/polaris/dataset/zarr/_utils.py
+++ b/polaris/dataset/zarr/_utils.py
@@ -1,6 +1,16 @@
 import zarr
 import zarr.storage
 
+from polaris.utils.errors import InvalidZarrCodec
+
+try:
+    # Register imagecodecs if they are available.
+    from imagecodecs.numcodecs import register_codecs
+
+    register_codecs()
+except ImportError:
+    pass
+
 
 def load_zarr_group_to_memory(group: zarr.Group) -> dict:
     """Loads an entire Zarr group into memory."""
@@ -19,14 +29,16 @@ def check_zarr_codecs(group: zarr.Group):
         for key, item in group.items():
             if isinstance(item, zarr.Group):
                 check_zarr_codecs(item)
+
     except ValueError as error:
         # Zarr raises a generic ValueError if a codec is not registered.
         # See also: https://github.com/zarr-developers/zarr-python/issues/2508
         prefix = "codec not available: "
-        message = str(error)
-        codec_id = message.removeprefix(prefix)
+        error_message = str(error)
 
-        if message.startswith(prefix):
-            raise RuntimeError(
-                f"This Zarr archive requires the {codec_id} codec. Install all optional codecs with 'pip install polaris-lib[codecs]'."
-            ) from error
+        if not error_message.startswith(prefix):
+            raise error
+
+        # Remove prefix and apostrophes
+        codec_id = error_message.removeprefix(prefix)[1:-1]
+        raise InvalidZarrCodec(codec_id)

--- a/polaris/utils/errors.py
+++ b/polaris/utils/errors.py
@@ -39,7 +39,7 @@ class InvalidZarrCodec(Exception):
         self.codec_id = codec_id
         super().__init__(
             f"This Zarr archive requires the {self.codec_id} codec. "
-            f"Install all optional codecs with 'pip install polaris-lib[codecs]'."
+            "Install all optional codecs with 'pip install polaris-lib[codecs]'."
         )
 
 

--- a/polaris/utils/errors.py
+++ b/polaris/utils/errors.py
@@ -32,6 +32,17 @@ class InvalidZarrChecksum(Exception):
     pass
 
 
+class InvalidZarrCodec(Exception):
+    """Raised when an expected codec is not registered."""
+
+    def __init__(self, codec_id: str):
+        self.codec_id = codec_id
+        super().__init__(
+            f"This Zarr archive requires the {self.codec_id} codec. "
+            f"Install all optional codecs with 'pip install polaris-lib[codecs]'."
+        )
+
+
 class PolarisHubError(Exception):
     BOLD = "\033[1m"
     YELLOW = "\033[93m"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ doc = [
     "nbconvert",
     "mike >=1.0.0"
 ]
+codecs = [
+    "imagecodecs",
+]
 
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "boto3>=1.35.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest",
     "pytest-xdist",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,9 +385,9 @@ def test_multi_task_benchmark_multiple_test_sets(test_dataset):
 
 
 @pytest.fixture(scope="function")
-def test_docking_dataset(tmpdir, sdf_files, test_org_owner):
+def test_docking_dataset(tmp_path, sdf_files, test_org_owner):
     # toy docking dataset
-    factory = DatasetFactory(tmpdir.join("ligands.zarr"))
+    factory = DatasetFactory(tmp_path / "ligands.zarr")
 
     converter = SDFConverter(mol_prop_as_cols=True)
     factory.register_converter("sdf", converter)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -127,9 +127,9 @@ def test_benchmark_metrics_verification(test_single_task_benchmark, test_multi_t
         )
 
 
-def test_benchmark_from_json(test_single_task_benchmark, tmpdir):
+def test_benchmark_from_json(test_single_task_benchmark, tmp_path):
     """Test whether we can successfully save and load a benchmark from JSON."""
-    path = test_single_task_benchmark.to_json(str(tmpdir))
+    path = test_single_task_benchmark.to_json(str(tmp_path))
     new_benchmark = SingleTaskBenchmarkSpecification.from_json(path)
     assert new_benchmark == test_single_task_benchmark
 

--- a/tests/test_competition.py
+++ b/tests/test_competition.py
@@ -5,9 +5,9 @@ from polaris.competition import CompetitionSpecification
 from polaris.evaluate.utils import evaluate_benchmark
 
 
-def test_competition_from_json(test_competition, tmpdir):
+def test_competition_from_json(test_competition, tmp_path):
     """Test whether we can successfully save and load a competition from JSON."""
-    path = test_competition.to_json(str(tmpdir))
+    path = test_competition.to_json(str(tmp_path))
     new_competition = CompetitionSpecification.from_json(path)
     assert new_competition == test_competition
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -231,8 +231,7 @@ def test_missing_codec_error(tmpdir):
         codec_id = "polaris_custom_test_codec"
 
         def encode(self, buf):
-            buf = b"Random bytes"
-            return buf
+            return b"Random bytes"
 
         def decode(self, buf, out=None):
             return np.random.random(100)

--- a/tests/test_dataset_v2.py
+++ b/tests/test_dataset_v2.py
@@ -13,7 +13,7 @@ from polaris.dataset import Subset
 from polaris.dataset._factory import DatasetFactory
 from polaris.dataset.converters._pdb import PDBConverter
 from polaris.dataset.zarr._manifest import generate_zarr_manifest
-from polaris.experimental._dataset_v2 import DatasetV2, _INDEX_ARRAY_KEY
+from polaris.experimental._dataset_v2 import _INDEX_ARRAY_KEY, DatasetV2
 
 
 def test_dataset_v2_get_columns(test_dataset_v2):
@@ -65,8 +65,8 @@ def test_dataset_v2_load_to_memory(test_dataset_v2):
     assert d2 < d1
 
 
-def test_dataset_v2_serialization(test_dataset_v2, tmpdir):
-    save_dir = tmpdir.join("save_dir")
+def test_dataset_v2_serialization(test_dataset_v2, tmp_path):
+    save_dir = tmp_path / "save_dir"
     path = test_dataset_v2.to_json(save_dir)
     new_dataset = DatasetV2.from_json(path)
     for i in range(5):
@@ -74,19 +74,19 @@ def test_dataset_v2_serialization(test_dataset_v2, tmpdir):
         assert np.array_equal(new_dataset.get_data(i, "B"), test_dataset_v2.get_data(i, "B"))
 
 
-def test_dataset_v2_caching(test_dataset_v2, tmpdir):
-    cache_dir = tmpdir.join("cache").strpath
+def test_dataset_v2_caching(test_dataset_v2, tmp_path):
+    cache_dir = str(tmp_path / "cache")
     test_dataset_v2._cache_dir = cache_dir
     test_dataset_v2.cache()
     assert str(test_dataset_v2.zarr_root_path).startswith(cache_dir)
 
 
-def test_dataset_v1_v2_compatibility(test_dataset, tmpdir):
+def test_dataset_v1_v2_compatibility(test_dataset, tmp_path):
     # A DataFrame is ultimately a collection of labeled numpy arrays
     # We can thus also saved these same arrays to a Zarr archive
     df = test_dataset.table
 
-    path = tmpdir.join("data/v1v2.zarr")
+    path = tmp_path / "data/v1v2.zarr"
 
     root = zarr.open(path, "w")
     root.array("smiles", data=df["smiles"].values, dtype=object, object_codec=numcodecs.VLenUTF8())
@@ -108,10 +108,10 @@ def test_dataset_v1_v2_compatibility(test_dataset, tmpdir):
         assert y1 == y2
 
 
-def test_dataset_v2_with_pdbs(pdb_paths, tmpdir):
+def test_dataset_v2_with_pdbs(pdb_paths, tmp_path):
     # The PDB example is interesting because it creates a more complex Zarr archive
     # that includes subgroups
-    zarr_root_path = str(tmpdir.join("pdbs.zarr"))
+    zarr_root_path = str(tmp_path / "pdbs.zarr")
     factory = DatasetFactory(zarr_root_path)
 
     # Build a V1 dataset

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -16,7 +16,7 @@ from polaris.evaluate._results import BenchmarkResults
 from polaris.utils.types import HubOwner
 
 
-def test_result_to_json(tmpdir: str, test_user_owner: HubOwner):
+def test_result_to_json(tmp_path: str, test_user_owner: HubOwner):
     scores = pd.DataFrame(
         {
             "Test set": ["A", "A", "A", "A", "B", "B", "B", "B"],
@@ -40,7 +40,7 @@ def test_result_to_json(tmpdir: str, test_user_owner: HubOwner):
         contributors=["my-user", "other-user"],
     )
 
-    path = os.path.join(tmpdir, "result.json")
+    path = os.path.join(tmp_path, "result.json")
     result.to_json(path)
     BenchmarkResults.from_json(path)
     assert po.__version__ == result.polaris_version

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -37,17 +37,17 @@ def _check_dataset(dataset, ground_truth, mol_props_as_col):
             assert "my_property" not in dataset.columns
 
 
-def test_sdf_zarr_conversion(sdf_file, caffeine, tmpdir):
+def test_sdf_zarr_conversion(sdf_file, caffeine, tmp_path):
     """Test conversion between SDF and Zarr with utility function"""
-    dataset = create_dataset_from_file(sdf_file, tmpdir.join("archive.zarr"))
+    dataset = create_dataset_from_file(sdf_file, tmp_path / "archive.zarr")
     _check_dataset(dataset, [caffeine], True)
 
 
 @pytest.mark.parametrize("mol_props_as_col", [True, False])
-def test_factory_sdf_with_prop_as_col(sdf_file, caffeine, tmpdir, mol_props_as_col):
+def test_factory_sdf_with_prop_as_col(sdf_file, caffeine, tmp_path, mol_props_as_col):
     """Test conversion between SDF and Zarr with factory pattern"""
 
-    factory = DatasetFactory(tmpdir.join("archive.zarr"))
+    factory = DatasetFactory(tmp_path / "archive.zarr")
 
     converter = SDFConverter(mol_prop_as_cols=mol_props_as_col)
     factory.register_converter("sdf", converter)
@@ -58,9 +58,9 @@ def test_factory_sdf_with_prop_as_col(sdf_file, caffeine, tmpdir, mol_props_as_c
     _check_dataset(dataset, [caffeine], mol_props_as_col)
 
 
-def test_zarr_to_zarr_conversion(zarr_archive, tmpdir):
+def test_zarr_to_zarr_conversion(zarr_archive, tmp_path):
     """Test conversion between Zarr and Zarr with utility function"""
-    dataset = create_dataset_from_file(zarr_archive, tmpdir.join("archive.zarr"))
+    dataset = create_dataset_from_file(zarr_archive, tmp_path / "archive.zarr")
     assert len(dataset) == 100
     assert len(dataset.columns) == 2
     assert all(c in dataset.columns for c in ["A", "B"])
@@ -68,10 +68,10 @@ def test_zarr_to_zarr_conversion(zarr_archive, tmpdir):
     assert dataset.get_data(row=0, col="A").shape == (2048,)
 
 
-def test_zarr_with_factory_pattern(zarr_archive, tmpdir):
+def test_zarr_with_factory_pattern(zarr_archive, tmp_path):
     """Test conversion between Zarr and Zarr with factory pattern"""
 
-    factory = DatasetFactory(tmpdir.join("archive.zarr"))
+    factory = DatasetFactory(tmp_path / "archive.zarr")
     converter = ZarrConverter()
     factory.register_converter("zarr", converter)
     factory.add_from_file(zarr_archive)
@@ -88,9 +88,9 @@ def test_zarr_with_factory_pattern(zarr_archive, tmpdir):
     assert dataset.table["C"].apply({1: "W", 2: "X", 3: "Y", 4: "Z"}.get).equals(dataset.table["D"])
 
 
-def test_factory_pdb(pdbs_structs, pdb_paths, tmpdir):
+def test_factory_pdb(pdbs_structs, pdb_paths, tmp_path):
     """Test conversion between PDB file and Zarr with factory pattern"""
-    factory = DatasetFactory(tmpdir.join("pdb.zarr"))
+    factory = DatasetFactory(tmp_path / "pdb.zarr")
 
     converter = PDBConverter()
     factory.register_converter("pdb", converter)
@@ -101,10 +101,10 @@ def test_factory_pdb(pdbs_structs, pdb_paths, tmpdir):
     _check_pdb_dataset(dataset, pdbs_structs[:1])
 
 
-def test_factory_pdbs(pdbs_structs, pdb_paths, tmpdir):
+def test_factory_pdbs(pdbs_structs, pdb_paths, tmp_path):
     """Test conversion between PDB files and Zarr with factory pattern"""
 
-    factory = DatasetFactory(tmpdir.join("pdbs.zarr"))
+    factory = DatasetFactory(tmp_path / "pdbs.zarr")
 
     converter = PDBConverter()
     factory.register_converter("pdb", converter)
@@ -116,19 +116,19 @@ def test_factory_pdbs(pdbs_structs, pdb_paths, tmpdir):
     _check_pdb_dataset(dataset, pdbs_structs)
 
 
-def test_pdbs_zarr_conversion(pdbs_structs, pdb_paths, tmpdir):
+def test_pdbs_zarr_conversion(pdbs_structs, pdb_paths, tmp_path):
     """Test conversion between PDBs and Zarr with utility function"""
 
-    dataset = create_dataset_from_files(pdb_paths, tmpdir.join("pdbs_2.zarr"), axis=0)
+    dataset = create_dataset_from_files(pdb_paths, tmp_path / "pdbs_2.zarr", axis=0)
 
     assert dataset.table.shape[0] == len(pdb_paths)
     _check_pdb_dataset(dataset, pdbs_structs)
 
 
-def test_factory_sdfs(sdf_files, caffeine, ibuprofen, tmpdir):
+def test_factory_sdfs(sdf_files, caffeine, ibuprofen, tmp_path):
     """Test conversion between SDF and Zarr with factory pattern"""
 
-    factory = DatasetFactory(tmpdir.join("sdfs.zarr"))
+    factory = DatasetFactory(tmp_path / "sdfs.zarr")
 
     converter = SDFConverter(mol_prop_as_cols=True)
     factory.register_converter("sdf", converter)
@@ -139,10 +139,10 @@ def test_factory_sdfs(sdf_files, caffeine, ibuprofen, tmpdir):
     _check_dataset(dataset, [caffeine, ibuprofen], True)
 
 
-def test_factory_sdf_pdb(sdf_file, pdb_paths, caffeine, pdbs_structs, tmpdir):
+def test_factory_sdf_pdb(sdf_file, pdb_paths, caffeine, pdbs_structs, tmp_path):
     """Test conversion between SDF and PDB from files to Zarr with factory pattern"""
 
-    factory = DatasetFactory(tmpdir.join("sdf_pdb.zarr"))
+    factory = DatasetFactory(tmp_path / "sdf_pdb.zarr")
 
     sdf_converter = SDFConverter(mol_prop_as_cols=False)
     factory.register_converter("sdf", sdf_converter)
@@ -157,8 +157,8 @@ def test_factory_sdf_pdb(sdf_file, pdb_paths, caffeine, pdbs_structs, tmpdir):
     _check_pdb_dataset(dataset, pdbs_structs[:1])
 
 
-def test_factory_from_files_same_column(sdf_files, pdb_paths, tmpdir):
-    factory = DatasetFactory(tmpdir.join("files.zarr"))
+def test_factory_from_files_same_column(sdf_files, pdb_paths, tmp_path):
+    factory = DatasetFactory(tmp_path / "files.zarr")
 
     sdf_converter = SDFConverter(mol_prop_as_cols=False)
     factory.register_converter("sdf", sdf_converter)

--- a/tests/test_zarr_checksum.py
+++ b/tests/test_zarr_checksum.py
@@ -106,11 +106,11 @@ def test_process_tree() -> None:
     assert checksum.digest == "e53fcb7b5c36b2f4647fbf826a44bdc9-2-2"
 
 
-def test_checksum_for_zarr_archive(zarr_archive, tmpdir):
+def test_checksum_for_zarr_archive(zarr_archive, tmp_path):
     # NOTE: This test was not in the original code base of the zarr-checksum package.
     checksum, _ = compute_zarr_checksum(zarr_archive)
 
-    path = tmpdir.join("copy")
+    path = tmp_path / "copy"
     copytree(zarr_archive, path)
     assert checksum == compute_zarr_checksum(str(path))[0]
 


### PR DESCRIPTION
## Changelogs

- Adds `imagecodecs` as an optional dependency.
- Throw an error with an actionable message when a codec is missing.
- Update test cases to use `tmp_path` rather than `tmpdir` ([ref](https://docs.pytest.org/en/stable/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures)).

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

Out of curiosity: Are there any design patterns to handle optional dependencies in Python systematically? I did a quick Google search, but couldn't find much. Maybe @jstlaurent knows?