### PR TITLE
feat: Add an optional username/password login mode

### DIFF
--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -166,10 +166,12 @@ class PolarisHubClient(OAuth2Client):
             return super().fetch_token(
                 username=self.settings.username,
                 password=self.settings.password,
-                grant_type="password" if self.settings.username and self.settings.password else "urn:ietf:params:oauth:grant-type:token-exchange",
-                **kwargs
+                grant_type="password"
+                if self.settings.username and self.settings.password
+                else "urn:ietf:params:oauth:grant-type:token-exchange",
+                **kwargs,
             )
-        except(OAuthError, OAuth2Error) as error:
+        except (OAuthError, OAuth2Error) as error:
             raise PolarisHubError(
                 message=f"Could not obtain a token to access the Hub. Error was: {error.error} - {error.description}"
             ) from error

--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -38,6 +38,8 @@ class PolarisHubSettings(BaseSettings):
 
     # Hub authentication settings
     hub_token_url: HttpUrlString | None = None
+    username: str | None = None
+    password: str | None = None
 
     # External authentication settings
     authorize_url: HttpUrlString = "https://clerk.polarishub.io/oauth/authorize"

--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -26,6 +26,11 @@ class PolarisHubSettings(BaseSettings):
         client_id: The OAuth2 client ID.
         ca_bundle: The path to a CA bundle file for requests.
             Allows for custom SSL certificates to be used.
+        default_timeout: The default timeout for requests.
+        hub_token_url: The URL of the Polaris Hub token endpoint.
+            A default value is generated based on the hub URL, and this should not need to be overridden.
+        username: The username for the Polaris Hub, for the optional password-based authentication.
+        password: The password for the specified username.
     """
 
     # Configuration of the pydantic model

--- a/polaris/hub/storage.py
+++ b/polaris/hub/storage.py
@@ -345,7 +345,7 @@ class StorageSession(OAuth2Client):
         Error handling for token fetching.
         """
         try:
-            return super().fetch_token()
+            return super().fetch_token(**kwargs)
         except (OAuthError, OAuth2Error) as error:
             raise PolarisHubError(
                 message=f"Could not obtain a token to access the storage backend. Error was: {error.error} - {error.description}"


### PR DESCRIPTION
## Changelogs

- Add optional settings for username and password
- Update token fetching from the Hub to use username/password when present

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---
When present, the Polaris Hub client will use the configured `POLARIS_USERNAME` and `POLARIS_PASSWORD` environment variables for authentication to the Hub, rather than an interactive login flow involving a browser session. This will only work for Polaris Hub users that have set a password on their account. The username is one of the email addresses associated with the Polaris Hub account.

This PR depends on a [PR on the Polaris Hub](https://github.com/polaris-hub/polaris-hub/pull/542), to enable the OAuth Resource Owner Password Credentials Grant.
