### PR TITLE
feat: Support result upload for XL benchmarks

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -280,7 +280,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
         return [m.name for m in v]
 
     @field_serializer("split")
-    def _serialize_split(self, v):
+    def _serialize_split(self, v: SplitType):
         """Convert any tuple to list to make sure it's serializable"""
         return listit(v)
 
@@ -317,6 +317,11 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         checksum = hash_fn.hexdigest()
         return checksum
+
+    @computed_field
+    @property
+    def dataset_artifact_id(self) -> str:
+        return self.dataset.artifact_id
 
     @computed_field
     @property
@@ -371,7 +376,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
     @computed_field
     @property
-    def test_set_sizes(self) -> list[str]:
+    def test_set_sizes(self) -> dict[str, int]:
         """The sizes of the test sets."""
         return {k: len(v) for k, v in self.split[1].items()}
 
@@ -491,7 +496,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
             y_prob=y_prob,
         )
 
-        return BenchmarkResults(results=scores, benchmark_name=self.name, benchmark_owner=self.owner)
+        return BenchmarkResults(results=scores, benchmark_artifact_id=self.artifact_id)
 
     def upload_to_hub(
         self,
@@ -540,20 +545,12 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
 
         return path
 
-    def _repr_dict_(self) -> dict:
-        """Utility function for pretty-printing to the command line and jupyter notebooks"""
-        repr_dict = self.model_dump()
-        repr_dict.pop("dataset")
-        repr_dict.pop("split")
-        repr_dict["dataset_name"] = self.dataset.name
-        return repr_dict
-
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """For pretty printing in Jupyter."""
-        return dict2html(self._repr_dict_())
+        return dict2html(self.model_dump(exclude={"dataset", "split"}))
 
     def __repr__(self):
-        return json.dumps(self._repr_dict_(), indent=2)
+        return self.model_dump_json(exclude={"dataset", "split"}, indent=2)
 
     def __str__(self):
         return self.__repr__()

--- a/polaris/dataset/_base.py
+++ b/polaris/dataset/_base.py
@@ -350,7 +350,7 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
         """Utility function for pretty-printing to the command line and jupyter notebooks"""
         raise NotImplementedError
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """For pretty-printing in Jupyter Notebooks"""
         return dict2html(self._repr_dict_())
 

--- a/polaris/evaluate/__init__.py
+++ b/polaris/evaluate/__init__.py
@@ -6,7 +6,6 @@ from polaris.evaluate._results import (
     CompetitionResults,
     EvaluationResult,
     ResultsMetadata,
-    ResultsType,
 )
 from polaris.evaluate.utils import evaluate_benchmark
 
@@ -17,7 +16,6 @@ __all__ = [
     "EvaluationResult",
     "BenchmarkResults",
     "CompetitionResults",
-    "ResultsType",
     "evaluate_benchmark",
     "CompetitionPredictions",
     "BenchmarkPredictions",

--- a/polaris/evaluate/_results.py
+++ b/polaris/evaluate/_results.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 import pandas as pd
 from pydantic import (
@@ -11,12 +11,12 @@ from pydantic import (
     computed_field,
     field_serializer,
     field_validator,
+    model_validator,
 )
 from pydantic.alias_generators import to_camel
 
 from polaris._artifact import BaseArtifactModel
 from polaris.evaluate import BenchmarkPredictions, Metric
-from polaris.hub.settings import PolarisHubSettings
 from polaris.utils.dict2html import dict2html
 from polaris.utils.errors import InvalidResultError
 from polaris.utils.misc import slugify
@@ -41,12 +41,13 @@ class ResultRecords(BaseModel):
 
     test_set: TestLabelType
     target_label: TargetLabelType
-    scores: dict[Union[Metric, str], float]
+    scores: dict[Metric, float]
 
     # Model config
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    @field_validator("scores")
+    @field_validator("scores", mode="before")
+    @classmethod
     def validate_scores(cls, v):
         validated = {}
         for metric, score in v.items():
@@ -59,12 +60,9 @@ class ResultRecords(BaseModel):
         return validated
 
     @field_serializer("scores")
-    def serialize_scores(self, value: dict):
+    def serialize_scores(self, value: dict[Metric, float]) -> dict[str, float]:
         """Change from the Metric enum to a string representation"""
         return {metric.name: score for metric, score in value.items()}
-
-
-ResultsType = Union[pd.DataFrame, list[ResultRecords | dict]]
 
 
 class ResultsMetadata(BaseArtifactModel):
@@ -79,16 +77,16 @@ class ResultsMetadata(BaseArtifactModel):
     """
 
     # Additional meta-data
-    github_url: Optional[HttpUrlString] = None
-    paper_url: Optional[HttpUrlString] = None
-    contributors: Optional[list[HubUser]] = None
+    github_url: HttpUrlString | None = None
+    paper_url: HttpUrlString | None = None
+    contributors: list[HubUser] = Field(default_factory=list)
 
     # Private attributes
     _created_at: datetime = PrivateAttr(default_factory=datetime.now)
 
     def _repr_dict_(self) -> dict:
         """Utility function for pretty-printing to the command line and jupyter notebooks"""
-        repr_dict = self.model_dump(exclude=["results"])
+        repr_dict = self.model_dump(exclude={"results"})
 
         df = self.results.copy(deep=True)
         df["Metric"] = df["Metric"].apply(lambda x: x.name if isinstance(x, Metric) else x)
@@ -131,34 +129,43 @@ class EvaluationResult(ResultsMetadata):
     RESULTS_COLUMNS: ClassVar[list[str]] = ["Test set", "Target label", "Metric", "Score"]
 
     # Results attribute
-    results: ResultsType
+    results: pd.DataFrame
+
+    @field_validator("results", mode="before")
+    @classmethod
+    def _convert_results(cls, v: list[ResultRecords | dict]) -> pd.DataFrame:
+        """
+        Convert the results to a dataframe if they are not already in that format
+        """
+        if isinstance(v, pd.DataFrame):
+            return v
+
+        try:
+            df = pd.DataFrame(columns=cls.RESULTS_COLUMNS)
+            for record in v:
+                if isinstance(record, dict):
+                    record = ResultRecords(**record)
+
+                for metric, score in record.scores.items():
+                    df.loc[len(df)] = {
+                        "Test set": record.test_set,
+                        "Target label": record.target_label,
+                        "Metric": metric,
+                        "Score": score,
+                    }
+            return df
+
+        except (ValueError, UnicodeDecodeError) as error:
+            raise InvalidResultError(
+                f"The provided dictionary cannot be parsed into a {cls.__name__} instance."
+            ) from error
 
     @field_validator("results")
-    def _validate_results(cls, v):
-        """Ensure the results are a valid dataframe and have the expected columns"""
-
-        # If not a dataframe, assume it is a JSON-serialized export of a dataframe.
-        if not isinstance(v, pd.DataFrame):
-            try:
-                df = pd.DataFrame(columns=cls.RESULTS_COLUMNS)
-                for record in v:
-                    if isinstance(record, dict):
-                        record = ResultRecords(**record)
-
-                    for metric, score in record.scores.items():
-                        df.loc[len(df)] = {
-                            "Test set": record.test_set,
-                            "Target label": record.target_label,
-                            "Metric": metric,
-                            "Score": score,
-                        }
-                v = df
-
-            except (ValueError, UnicodeDecodeError) as error:
-                raise InvalidResultError(
-                    f"The provided dictionary cannot be parsed into a {cls.__name__} instance."
-                ) from error
-
+    @classmethod
+    def _validate_results(cls, v: pd.DataFrame):
+        """
+        Ensure the results are a valid dataframe and have the expected columns
+        """
         # Check if the dataframe contains _only_ the expected columns
         if set(v.columns) != set(cls.RESULTS_COLUMNS):
             raise InvalidResultError(
@@ -176,7 +183,7 @@ class EvaluationResult(ResultsMetadata):
         return v
 
     @field_serializer("results")
-    def _serialize_results(self, value: ResultsType):
+    def _serialize_results(self, value: pd.DataFrame):
         """Change from the Metric enum to a string representation"""
         self.results["Metric"] = self.results["Metric"].apply(
             lambda x: x.name if isinstance(x, Metric) else x
@@ -207,29 +214,29 @@ class BenchmarkResults(EvaluationResult):
 
     _artifact_type = "result"
 
-    benchmark_name: SlugCompatibleStringType = Field(..., frozen=True)
-    benchmark_owner: Optional[HubOwner] = Field(None, frozen=True)
+    benchmark_artifact_id: str = Field(None)
+    benchmark_name: SlugCompatibleStringType | None = Field(None, deprecated=True)
+    benchmark_owner: HubOwner | None = Field(None, deprecated=True)
 
-    @computed_field
-    @property
-    def benchmark_artifact_id(self) -> str:
-        return f"{self.benchmark_owner}/{slugify(self.benchmark_name)}"
+    @model_validator(mode="after")
+    def set_benchmark_artifact_id(self):
+        if self.benchmark_artifact_id is None:
+            self.benchmark_artifact_id = f"{self.benchmark_owner}/{slugify(self.benchmark_name)}"
+        return self
 
     def upload_to_hub(
         self,
-        settings: Optional[PolarisHubSettings] = None,
-        cache_auth_token: bool = True,
-        access: Optional[AccessType] = "private",
-        owner: Union[HubOwner, str, None] = None,
+        access: AccessType = "private",
+        owner: HubOwner | str | None = None,
         **kwargs: dict,
-    ):
+    ) -> "BenchmarkResults":
         """
         Very light, convenient wrapper around the
         [`PolarisHubClient.upload_results`][polaris.hub.client.PolarisHubClient.upload_results] method.
         """
         from polaris.hub.client import PolarisHubClient
 
-        with PolarisHubClient(settings=settings, cache_auth_token=cache_auth_token, **kwargs) as client:
+        with PolarisHubClient(**kwargs) as client:
             return client.upload_results(self, access=access, owner=owner)
 
 
@@ -250,7 +257,7 @@ class CompetitionResults(EvaluationResult):
     _artifact_type = "competitionResult"
 
     competition_name: SlugCompatibleStringType = Field(..., frozen=True)
-    competition_owner: Optional[HubOwner] = Field(None, frozen=True)
+    competition_owner: HubOwner | None = Field(None, frozen=True)
 
     @computed_field
     @property
@@ -270,4 +277,4 @@ class CompetitionPredictions(ResultsMetadata, BenchmarkPredictions):
         access: The access the returned results should have
     """
 
-    access: Optional[AccessType] = "private"
+    access: AccessType = "private"

--- a/polaris/evaluate/_results.py
+++ b/polaris/evaluate/_results.py
@@ -122,7 +122,7 @@ class EvaluationResult(ResultsMetadata):
 
     @field_validator("results", mode="before")
     @classmethod
-    def _convert_results(cls, v: list[ResultRecords | dict]) -> pd.DataFrame:
+    def _convert_results(cls, v: pd.DataFrame | list[ResultRecords | dict]) -> pd.DataFrame:
         """
         Convert the results to a dataframe if they are not already in that format
         """

--- a/polaris/evaluate/utils.py
+++ b/polaris/evaluate/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
 
-from polaris.evaluate import BenchmarkPredictions, BenchmarkResults, Metric, ResultsType
+from polaris.evaluate import BenchmarkPredictions, BenchmarkResults, Metric
 from polaris.utils.types import IncomingPredictionsType
 
 
@@ -91,7 +91,7 @@ def evaluate_benchmark(
 
     # Compute the results
     # Results are saved in a tabular format. For more info, see the BenchmarkResults docs.
-    scores: ResultsType = pd.DataFrame(columns=BenchmarkResults.RESULTS_COLUMNS)
+    scores = pd.DataFrame(columns=BenchmarkResults.RESULTS_COLUMNS)
 
     # For every test set...
     for test_label, y_true_test in y_true.predictions.items():

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -181,13 +181,12 @@ class PolarisHubClient(OAuth2Client):
                 message=f"Could not obtain a token to access the Hub. Error was: {error.error} - {error.description}"
             ) from error
 
-    def _base_request_to_hub(self, url: str, method: str, **kwargs):
+    def _base_request_to_hub(self, url: str, method: str, **kwargs) -> Response:
         """Utility function since most API methods follow the same pattern"""
         response = self.request(url=url, method=method, **kwargs)
-
         try:
             response.raise_for_status()
-
+            return response
         except HTTPStatusError as error:
             response_status_code = response.status_code
 
@@ -220,13 +219,6 @@ class PolarisHubClient(OAuth2Client):
                 raise PolarisRetrieveArtifactError(response=response) from error
 
             raise PolarisHubError(response=response) from error
-        # Convert the response to json format if the response contains a 'text' body
-        try:
-            response = response.json()
-        except json.JSONDecodeError:
-            pass
-
-        return response
 
     def get_metadata_from_response(self, response: Response, key: str) -> str | None:
         """Get custom metadata saved to the R2 object from the headers."""
@@ -302,7 +294,8 @@ class PolarisHubClient(OAuth2Client):
             response = self._base_request_to_hub(
                 url="/v1/dataset", method="GET", params={"limit": limit, "offset": offset}
             )
-            dataset_list = [bm["artifactId"] for bm in response["data"]]
+            response_data = response.json()
+            dataset_list = [bm["artifactId"] for bm in response_data["data"]]
 
             return dataset_list
 
@@ -358,9 +351,10 @@ class PolarisHubClient(OAuth2Client):
             else f"/v2/competition/dataset/{owner}/{name}"
         )
         response = self._base_request_to_hub(url=url, method="GET")
+        response_data = response.json()
 
         # Disregard the Zarr root in the response. We'll get it from the storage token instead.
-        response.pop("zarrRootPath", None)
+        response_data.pop("zarrRootPath", None)
 
         # Load the dataset table and optional Zarr archive
         with StorageSession(self, "read", Dataset.urn_for(owner, name)) as storage:
@@ -373,11 +367,11 @@ class PolarisHubClient(OAuth2Client):
                 zarr_root_path = str(zarr_root_path)
 
         if artifact_type == ArtifactSubtype.COMPETITION:
-            dataset = CompetitionDataset(table=table, zarr_root_path=zarr_root_path, **response)
-            md5sum = response["maskedMd5Sum"]
+            dataset = CompetitionDataset(table=table, zarr_root_path=zarr_root_path, **response_data)
+            md5sum = response_data["maskedMd5Sum"]
         else:
-            dataset = DatasetV1(table=table, zarr_root_path=zarr_root_path, **response)
-            md5sum = response["md5Sum"]
+            dataset = DatasetV1(table=table, zarr_root_path=zarr_root_path, **response_data)
+            md5sum = response_data["md5Sum"]
 
         if dataset.should_verify_checksum(verify_checksum):
             dataset.verify_checksum(md5sum)
@@ -390,15 +384,16 @@ class PolarisHubClient(OAuth2Client):
         """"""
         url = f"/v2/dataset/{owner}/{name}"
         response = self._base_request_to_hub(url=url, method="GET")
+        response_data = response.json()
 
         # Disregard the Zarr root in the response. We'll get it from the storage token instead.
-        response.pop("zarrRootPath", None)
+        response_data.pop("zarrRootPath", None)
 
         # Load the Zarr archive
         with StorageSession(self, "read", Dataset.urn_for(owner, name)) as storage:
             zarr_root_path = str(storage.paths.root)
 
-        dataset = DatasetV2(zarr_root_path=zarr_root_path, **response)
+        dataset = DatasetV2(zarr_root_path=zarr_root_path, **response_data)
         return dataset
 
     def list_benchmarks(self, limit: int = 100, offset: int = 0) -> list[str]:
@@ -420,7 +415,8 @@ class PolarisHubClient(OAuth2Client):
             response = self._base_request_to_hub(
                 url="/v1/benchmark", method="GET", params={"limit": limit, "offset": offset}
             )
-            benchmarks_list = [f"{HubOwner(**bm['owner'])}/{bm['name']}" for bm in response["data"]]
+            response_data = response.json()
+            benchmarks_list = [f"{HubOwner(**bm['owner'])}/{bm['name']}" for bm in response_data["data"]]
 
             return benchmarks_list
 
@@ -446,12 +442,13 @@ class PolarisHubClient(OAuth2Client):
             error_msg="Failed to fetch benchmark.",
         ):
             response = self._base_request_to_hub(url=f"/v1/benchmark/{owner}/{name}", method="GET")
+            response_data = response.json()
 
             # TODO (jstlaurent): response["dataset"]["artifactId"] is the owner/name unique identifier,
             #  but we'd need to change the signature of get_dataset to use it
-            response["dataset"] = self.get_dataset(
-                response["dataset"]["owner"]["slug"],
-                response["dataset"]["name"],
+            response_data["dataset"] = self.get_dataset(
+                response_data["dataset"]["owner"]["slug"],
+                response_data["dataset"]["name"],
                 verify_checksum=verify_checksum,
             )
 
@@ -459,16 +456,16 @@ class PolarisHubClient(OAuth2Client):
             #  Maybe through structural pattern matching, introduced in Py3.10, or Pydantic's discriminated unions?
             benchmark_cls = (
                 SingleTaskBenchmarkSpecification
-                if len(response["targetCols"]) == 1
+                if len(response_data["targetCols"]) == 1
                 else MultiTaskBenchmarkSpecification
             )
 
-            benchmark = benchmark_cls(**response)
+            benchmark = benchmark_cls(**response_data)
 
             if benchmark.dataset.should_verify_checksum(verify_checksum):
                 benchmark.verify_checksum()
             else:
-                benchmark.md5sum = response["md5Sum"]
+                benchmark.md5sum = response_data["md5Sum"]
 
             return benchmark
 
@@ -477,7 +474,7 @@ class PolarisHubClient(OAuth2Client):
         results: BenchmarkResults,
         access: AccessType = "private",
         owner: HubOwner | str | None = None,
-    ):
+    ) -> BenchmarkResults:
         """Upload the results to the Polaris Hub.
 
         Info: Owner
@@ -490,11 +487,6 @@ class PolarisHubClient(OAuth2Client):
             The requirements by the hub are stricter, so when uploading to the hub you might
             get some errors on missing meta-data. Make sure to fill-in as much of the meta-data as possible
             before uploading.
-
-        Note: Benchmark name and owner
-            Importantly, `results.benchmark_name` and `results.benchmark_owner` must be specified
-            and match an existing benchmark on the Polaris Hub. If these results were generated by
-            `benchmark.evaluate(...)`, this is done automatically.
 
         Args:
             results: The results to upload.
@@ -512,20 +504,16 @@ class PolarisHubClient(OAuth2Client):
 
             # Make a request to the hub
             response = self._base_request_to_hub(
-                url="/v1/result", method="POST", json={"access": access, **result_json}
+                url="/v2/result", method="POST", json={"access": access, **result_json}
             )
 
             # Inform the user about where to find their newly created artifact.
-            result_url = urljoin(
-                self.settings.hub_url,
-                f"/v1/benchmarks/{results.benchmark_owner}/{results.benchmark_name}/{response['id']}",
-            )
+            result_url = urljoin(self.settings.hub_url, response.headers.get("Content-Location"))
 
             progress_indicator.update_success_msg(
                 f"Your result has been successfully uploaded to the Hub. View it here: {result_url}"
             )
-
-            return response
+            return results
 
     def upload_dataset(
         self,
@@ -637,6 +625,7 @@ class PolarisHubClient(OAuth2Client):
                 },
                 timeout=timeout,
             )
+            response_data = response.json()
 
             with StorageSession(self, "write", dataset.urn) as storage:
                 # Step 2: Upload the parquet file
@@ -672,7 +661,7 @@ class PolarisHubClient(OAuth2Client):
                 f"View it here: {urljoin(self.settings.hub_url, f'{base_artifact_url}/{dataset.owner}/{dataset.name}')}"
             )
 
-            return response
+            return response_data
 
     def _upload_v2_dataset(
         self,
@@ -709,6 +698,7 @@ class PolarisHubClient(OAuth2Client):
                 },
                 timeout=timeout,
             )
+            response_data = response.json()
 
             with StorageSession(self, "write", dataset.urn) as storage:
                 # Step 2: Upload the manifest file
@@ -741,7 +731,7 @@ class PolarisHubClient(OAuth2Client):
             f"View it here: {urljoin(self.settings.hub_url, f'datasets/{dataset.owner}/{dataset.name}')}"
         )
 
-        return response
+        return response_data
 
     def upload_benchmark(
         self,
@@ -818,12 +808,13 @@ class PolarisHubClient(OAuth2Client):
             )
             url = f"{path_params}/{benchmark.owner}/{benchmark.name}"
             response = self._base_request_to_hub(url=url, method="PUT", json=benchmark_json)
+            response_data = response.json()
 
             progress_indicator.update_success_msg(
                 f"Your {artifact_type} benchmark has been successfully uploaded to the Hub. "
                 f"View it here: {urljoin(self.settings.hub_url, url)}"
             )
-            return response
+            return response_data
 
     def get_competition(
         self,
@@ -842,20 +833,21 @@ class PolarisHubClient(OAuth2Client):
             A `CompetitionSpecification` instance, if it exists.
         """
         response = self._base_request_to_hub(url=f"/v2/competition/{owner}/{name}", method="GET")
+        response_data = response.json()
 
         # TODO (jstlaurent): response["dataset"]["artifactId"] is the owner/name unique identifier,
         #  but we'd need to change the signature of get_dataset to use it
-        response["dataset"] = self._get_v1_dataset(
-            response["dataset"]["owner"]["slug"],
-            response["dataset"]["name"],
+        response_data["dataset"] = self._get_v1_dataset(
+            response_data["dataset"]["owner"]["slug"],
+            response_data["dataset"]["name"],
             ArtifactSubtype.COMPETITION,
             verify_checksum=verify_checksum,
         )
 
         if not verify_checksum:
-            response.pop("md5Sum", None)
+            response_data.pop("md5Sum", None)
 
-        return CompetitionSpecification.model_construct(**response)
+        return CompetitionSpecification.model_construct(**response_data)
 
     def list_competitions(self, limit: int = 100, offset: int = 0) -> list[str]:
         """List all available competitions on the Polaris Hub.
@@ -876,7 +868,8 @@ class PolarisHubClient(OAuth2Client):
             response = self._base_request_to_hub(
                 url="/v2/competition", method="GET", params={"limit": limit, "offset": offset}
             )
-            competitions_list = [f"{HubOwner(**bm['owner'])}/{bm['name']}" for bm in response["data"]]
+            response_data = response.json()
+            competitions_list = [f"{HubOwner(**bm['owner'])}/{bm['name']}" for bm in response_data["data"]]
             return competitions_list
 
     def evaluate_competition(
@@ -906,17 +899,18 @@ class PolarisHubClient(OAuth2Client):
                 method="POST",
                 json=competition_predictions.model_dump(),
             )
+            response_data = response.json()
 
             # Inform the user about where to find their newly created artifact.
             result_url = urljoin(
                 self.settings.hub_url,
-                f"/v2/competition/{competition.owner}/{competition.name}/{response['id']}",
+                f"/v2/competition/{competition.owner}/{competition.name}/{response_data['id']}",
             )
             progress_indicator.update_success_msg(
                 f"Your competition result has been successfully uploaded to the Hub. View it here: {result_url}"
             )
 
-            scores = response["results"]
+            scores = response_data["results"]
             return CompetitionResults(
                 results=scores, competition_name=competition.name, competition_owner=competition.owner
             )


### PR DESCRIPTION
## Changelogs

- Update the `upload_results` client method to us the new V2 API endpoint in the Hub
- Tighten types in Pydantic models to reflect the data structure once parsing is complete
- Update client base request method to return the httpx response, in order to make headers accessible.


## Linked issues

- Closes [PRO-175]

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

This PR updates the client to use the new V2 API endpoint for results. This will enable uploading supports for the upcoming V2 Benchmarks. Due to the nature of the result model in the client, which holds 
their related benchmark identitifer but not an object reference, the same endpoint must accomodate both V1 and V2 benchmarks.

I also took the opportunity to tighten the typing in some Pydantic models. We had initially typed our models liberally, to show what could be accepted as inputs. While this still holds, the reality is that 
our models normalized these input values to one representation. The updated model typing represents that normalized representation.

The new V2 result endpoint also now returns a [Content-Location](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Location) response header, which will provide the URL of the result on the 
Hub. To leverage this, I exposed the full response object to the calling functions, instead of only the JSON body.
