### PR TITLE
Fix: Optimize PDB adapter

### DIFF
--- a/polaris/dataset/converters/_pdb.py
+++ b/polaris/dataset/converters/_pdb.py
@@ -166,8 +166,10 @@ class PDBConverter(Converter):
         # Create group and add
         if append:
             if self.pdb_column not in factory.zarr_root:
-                raise RuntimeError(f"Group {self.pdb_column} doesn't exist in {factory.zarr_root}. \
-                    Please make sure the Group {self.pdb_column} is created. Or set `append` to `False`.")
+                raise RuntimeError(
+                    f"Group {self.pdb_column} doesn't exist in {factory.zarr_root}. \
+                    Please make sure the Group {self.pdb_column} is created. Or set `append` to `False`."
+                )
             else:
                 pdb_group = factory.zarr_root[self.pdb_column]
         else:

--- a/polaris/dataset/converters/_sdf.py
+++ b/polaris/dataset/converters/_sdf.py
@@ -107,8 +107,10 @@ class SDFConverter(Converter):
 
         if append:
             if self.mol_column not in factory.zarr_root:
-                raise RuntimeError(f"Array {self.mol_column} doesn't exist in {factory.zarr_root}. \
-                    Please make sure the Array is created. Or set `append` to `False`.")
+                raise RuntimeError(
+                    f"Array {self.mol_column} doesn't exist in {factory.zarr_root}. \
+                    Please make sure the Array is created. Or set `append` to `False`."
+                )
             else:
                 # append existing array
                 pointer_start = factory.zarr_root[self.mol_column].shape[0]

--- a/polaris/dataset/converters/_zarr.py
+++ b/polaris/dataset/converters/_zarr.py
@@ -39,8 +39,10 @@ class ZarrConverter(Converter):
         pointer_start_dict = {col: 0 for col, _ in src.arrays()}
         if append:
             if not os.path.exists(factory.zarr_root.store.path):
-                raise RuntimeError(f"Zarr store {factory.zarr_root.store.path} doesn't exist. \
-                    Please make sure the zarr store {factory.zarr_root.store.path} is created. Or set `append` to `False`.")
+                raise RuntimeError(
+                    f"Zarr store {factory.zarr_root.store.path} doesn't exist. \
+                    Please make sure the zarr store {factory.zarr_root.store.path} is created. Or set `append` to `False`."
+                )
             else:
                 for col, arr in src.arrays():
                     pointer_start_dict[col] += factory.zarr_root[col].shape[0]

--- a/polaris/dataset/zarr/_utils.py
+++ b/polaris/dataset/zarr/_utils.py
@@ -14,6 +14,12 @@ except ImportError:
 
 def load_zarr_group_to_memory(group: zarr.Group) -> dict:
     """Loads an entire Zarr group into memory."""
+
+    if isinstance(group, dict):
+        # If a Zarr group is already loaded to memory (e.g. with dataset.load_to_memory()),
+        # the adapter would receive a dictionary instead of a Zarr group.
+        return group
+
     data = {}
     for key, item in group.items():
         if isinstance(item, zarr.Array):

--- a/polaris/experimental/_dataset_v2.py
+++ b/polaris/experimental/_dataset_v2.py
@@ -180,8 +180,10 @@ class DatasetV2(BaseDataset):
 
         # If it is a group, there is no deterministic order for the child keys.
         # We therefore use a special array that defines the index.
-        if isinstance(group_or_array, zarr.Group):
-            row = group_or_array[_INDEX_ARRAY_KEY][row]
+        # If loaded to memory, the group is represented by a dictionary.
+        if isinstance(group_or_array, zarr.Group) or isinstance(group_or_array, dict):
+            # Indices in a group should always be strings
+            row = str(group_or_array[_INDEX_ARRAY_KEY][row])
         arr = group_or_array[row]
 
         # Adapt the input to the specified format


### PR DESCRIPTION
## Changelogs

- Load Zarr array to memory before converting from Zarr Group to AtomArray for PDB files. 
- Indices into a Zarr Group should always be strings.

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._
