### PR TITLE
chore: Optimize Zarr store copy operation to Hub storage

### DIFF
--- a/polaris/dataset/_base.py
+++ b/polaris/dataset/_base.py
@@ -1,7 +1,7 @@
 import abc
 import json
 from os import PathLike
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, MutableMapping
 from uuid import uuid4
 
@@ -126,7 +126,7 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
         Set the default cache dir if none and make sure it exists
         """
         if self._cache_dir is None:
-            self._cache_dir = str(Path(DEFAULT_CACHE_DIR) / _CACHE_SUBDIR / str(uuid4()))
+            self._cache_dir = str(PurePath(DEFAULT_CACHE_DIR) / _CACHE_SUBDIR / str(uuid4()))
         fs, path = fsspec.url_to_fs(self._cache_dir)
         fs.mkdirs(path, exist_ok=True)
 
@@ -365,8 +365,8 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
         if not self.uses_zarr:
             return
 
-        current_zarr_root = Path(self.zarr_root_path)
-        destination_zarr_root = Path(destination) / current_zarr_root.name
+        current_zarr_root = PurePath(self.zarr_root_path)
+        destination_zarr_root = PurePath(destination) / current_zarr_root.name
 
         # Copy over Zarr data to the destination
         self._warn_about_remote_zarr = False

--- a/polaris/dataset/_base.py
+++ b/polaris/dataset/_base.py
@@ -310,7 +310,7 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_json(self, destination: str, if_exists: ZarrConflictResolution = "replace") -> str:
+    def to_json(self, destination: str | Path, if_exists: ZarrConflictResolution = "replace") -> str:
         """
         Save the dataset to a destination directory as a JSON file.
 
@@ -372,15 +372,15 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
         self._warn_about_remote_zarr = False
 
         logger.info(f"Copying Zarr archive to {destination_zarr_root}. This may take a while.")
-        destination_store = zarr.open(str(destination_zarr_root), "w")
+        destination_store = zarr.open(str(destination_zarr_root), "w").store
         source_store = self.zarr_root.store.store
 
         if isinstance(source_store, S3Store):
-            source_store.copy_to_destination(destination_store.store, if_exists, logger.info)
+            source_store.copy_to_destination(destination_store, if_exists, logger.info)
         else:
             zarr.copy_store(
-                source=self.zarr_root.store.store,
-                dest=destination_store.store,
+                source=source_store,
+                dest=destination_store,
                 log=logger.info,
                 if_exists=if_exists,
             )

--- a/polaris/experimental/_dataset_v2.py
+++ b/polaris/experimental/_dataset_v2.py
@@ -217,7 +217,7 @@ class DatasetV2(BaseDataset):
 
     def to_json(
         self,
-        destination: str,
+        destination: str | Path,
         if_exists: ZarrConflictResolution = "replace",
     ) -> str:
         """

--- a/polaris/experimental/_dataset_v2.py
+++ b/polaris/experimental/_dataset_v2.py
@@ -1,5 +1,6 @@
 import json
 import re
+from os import PathLike
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
@@ -218,7 +219,6 @@ class DatasetV2(BaseDataset):
         self,
         destination: str,
         if_exists: ZarrConflictResolution = "replace",
-        load_zarr_from_new_location: bool = False,
     ) -> str:
         """
         Save the dataset to a destination directory as a JSON file.
@@ -227,8 +227,6 @@ class DatasetV2(BaseDataset):
             destination: The _directory_ to save the associated data to.
             if_exists: Action for handling existing files in the Zarr archive. Options are 'raise' to throw
                 an error, 'replace' to overwrite, or 'skip' to proceed without altering the existing files.
-            load_zarr_from_new_location: Whether to update the current instance to load data from the location
-                the data is saved to.
 
         Returns:
             The path to the JSON file.
@@ -236,45 +234,41 @@ class DatasetV2(BaseDataset):
         destination = Path(destination)
         destination.mkdir(exist_ok=True, parents=True)
 
-        dataset_path = str(destination / "dataset.json")
-        new_zarr_root_path = str(destination / "data.zarr")
+        # Make a copy to cache the data, and then serialize that
+        copy = self.model_copy()
+        copy.cache(destination, if_exists=if_exists)
 
-        # Lu: Avoid serializing and sending None to hub app.
-        serialized = self.model_dump(
+        serialized = copy.model_dump_json(
             exclude_none=True, exclude={"zarr_manifest_path", "zarr_manifest_md5sum"}
         )
-        serialized["zarrRootPath"] = new_zarr_root_path
 
-        # Copy over Zarr data to the destination
-        self._warn_about_remote_zarr = False
+        destination_json = destination / f"{copy.slug}.json"
+        destination_json.write_text(serialized)
+        return str(destination_json)
 
-        logger.info(f"Copying Zarr archive to {new_zarr_root_path}. This may take a while.")
-        dest = zarr.open(new_zarr_root_path, "w")
+    def cache(
+        self, destination: str | PathLike | None = None, if_exists: ZarrConflictResolution = "replace"
+    ) -> str:
+        """
+        Caches the dataset by downloading the Zarr archive to a local directory.
 
-        zarr.copy_store(
-            source=self.zarr_root.store.store,
-            dest=dest.store,
-            log=logger.debug,
-            if_exists=if_exists,
-        )
-
-        if load_zarr_from_new_location:
-            self.zarr_root_path = new_zarr_root_path
-            self._zarr_root = None
-            self._zarr_data = None
-
-        with fsspec.open(dataset_path, "w") as f:
-            json.dump(serialized, f)
-        return dataset_path
-
-    def cache(self) -> str:
-        """Caches the dataset by downloading all additional data for pointer columns to a local directory.
+        Args:
+            destination: The directory to cache the data to. If None, will use the default cache directory.
+            if_exists: Action for handling existing files at the destination. Options are 'raise' to throw
+                an error, 'replace' to overwrite, or 'skip' to proceed without altering the existing files.
 
         Returns:
-            The path to the cache directory.
+            The path to the directory where data has been cached to.
         """
-        self.to_json(self._cache_dir, load_zarr_from_new_location=True)
-        return self._cache_dir
+        if not destination:
+            destination = self._cache_dir
+
+        destination = Path(destination)
+        destination.mkdir(exist_ok=True, parents=True)
+
+        self._cache_zarr(destination, if_exists)
+
+        return str(destination)
 
     def _repr_dict_(self) -> dict:
         """Utility function for pretty-printing to the command line and jupyter notebooks"""

--- a/polaris/experimental/_dataset_v2.py
+++ b/polaris/experimental/_dataset_v2.py
@@ -228,7 +228,7 @@ class DatasetV2(BaseDataset):
             if_exists: Action for handling existing files in the Zarr archive. Options are 'raise' to throw
                 an error, 'replace' to overwrite, or 'skip' to proceed without altering the existing files.
             load_zarr_from_new_location: Whether to update the current instance to load data from the location
-                the data is saved to. Only relevant for Zarr-datasets.
+                the data is saved to.
 
         Returns:
             The path to the JSON file.

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -646,11 +646,8 @@ class PolarisHubClient(OAuth2Client):
                     destination[".zmetadata"] = zmetadata_content
 
                     # Copy the Zarr archive to the hub
-                    zarr.copy_store(
-                        source=dataset.zarr_root.store.store,
-                        dest=destination,
-                        log=logger.debug,
-                        if_exists=if_exists,
+                    destination.copy_from_source(
+                        dataset.zarr_root.store.store, if_exists=if_exists, log=logger.info
                     )
 
             base_artifact_url = (
@@ -719,11 +716,8 @@ class PolarisHubClient(OAuth2Client):
                 destination[".zmetadata"] = zmetadata_content
 
                 # Copy the Zarr archive to the hub
-                zarr.copy_store(
-                    source=dataset.zarr_root.store.store,
-                    dest=destination,
-                    log=logger.debug,
-                    if_exists=if_exists,
+                destination.copy_from_source(
+                    dataset.zarr_root.store.store, if_exists=if_exists, log=logger.info
                 )
 
         progress_indicator.update_success_msg(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -100,7 +100,7 @@ def test_dataset_from_json(test_dataset, tmp_path):
     """Test whether the dataset can be saved and loaded from json."""
     test_dataset.to_json(str(tmp_path))
 
-    path = fs.join(str(tmp_path), "dataset.json")
+    path = fs.join(str(tmp_path), f"{test_dataset.slug}.json")
 
     new_dataset = DatasetV1.from_json(path)
     assert test_dataset == new_dataset


### PR DESCRIPTION
## Changelogs

- Implement a custom Zarr store copy operation in the `S3Store`

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

A recent dataset added to the Hub sported a Zarr archive of modest size, but with a large number of files (194.056 MiB, 5067 files). The large number of files and the overhead of copying them to the Hub storage resulted in a transfer time of over 30 minutes. For comparison, using [Rclone](https://rclone.org/) to transfer the same Zarr archive to the same storage backend required 7 minutes.

The root cause of the client's slow upload lies in the implementation of the [`zarr.copy_store`](https://zarr.readthedocs.io/en/stable/api/convenience.html#zarr.convenience.copy_store) we use in our `StorageSession` class. This implementation makes no assumption about the nature of the source or destination stores, so it uses the most basic API supported by a Zarr store, [`MutableMapping`](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping). It sequentially iterates through every key in the source store, checks their presence in the destination store, and then adds them to that store.

This PR updates our `S3Store` implementation with a custom copy method, that can leverage more efficient S3 operations, as well as parallel and concurrent operations, to improve throughput. The above mentioned dataset can now be copied to the Hub storage in ~2 minutes.
