### PR TITLE
Fix: Add alias for `custom_name` in `Metric`

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -171,7 +171,7 @@ class BenchmarkSpecification(BaseArtifactModel, ChecksumMixin):
         unique_names = {m.name for m in unique_metrics}
         if len(unique_names) != len(unique_metrics):
             raise InvalidBenchmarkError(
-                "The benchmark has similarly named metrics. Specify a custom name with Metric(custom_name=...)"
+                "The metrics of a benchmark need to have unique names. Specify a custom name with Metric(custom_name=...)"
             )
 
         return unique_metrics

--- a/polaris/evaluate/_metric.py
+++ b/polaris/evaluate/_metric.py
@@ -285,7 +285,7 @@ class Metric(BaseModel):
 
     label: MetricLabel
     config: GroupedMetricConfig | None = None
-    custom_name: str | None = Field(None, exclude=True)
+    custom_name: str | None = Field(None, exclude=True, alias="name")
 
     # Frozen metadata
     fn: Callable = Field(frozen=True, exclude=True)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -233,7 +233,7 @@ def test_benchmark_duplicate_metrics(test_single_task_benchmark):
         m["main_metric"] = m["metrics"][0]
         SingleTaskBenchmarkSpecification(**m)
 
-    with pytest.raises(ValidationError, match="The benchmark has similarly named metrics"):
+    with pytest.raises(ValidationError, match="The metrics of a benchmark need to have unique names."):
         m["metrics"][0].config.group_by = "MULTICLASS_calc"
         SingleTaskBenchmarkSpecification(**m)
 


### PR DESCRIPTION
## Changelogs

- Add an alias to the `custom_name` to match behavior on Hub. 
- Clarify error message

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

I'll merge this without review given the urgency.
