### PR TITLE
Support a new group structure for columns

### DIFF
--- a/tests/test_benchmark_v2.py
+++ b/tests/test_benchmark_v2.py
@@ -113,7 +113,7 @@ def test_benchmark_v2_specification(valid_split, test_dataset_v2, tmp_path):
     BenchmarkV2Specification(**config)
 
 
-def test_benchmark_v2_invalid_indices(valid_split, test_dataset_v2):
+def test_benchmark_v2_invalid_indices(test_dataset_v2):
     """
     Test validation of indices against dataset length
     """

--- a/tests/test_dataset_v2.py
+++ b/tests/test_dataset_v2.py
@@ -1,5 +1,4 @@
 import os
-from copy import deepcopy
 from time import perf_counter
 
 import numcodecs
@@ -10,36 +9,46 @@ import zarr
 from pydantic import ValidationError
 
 from polaris.dataset import DatasetV2, Subset
-from polaris.dataset._dataset_v2 import _INDEX_ARRAY_KEY
-from polaris.dataset._factory import DatasetFactory
-from polaris.dataset.converters._pdb import PDBConverter
+from polaris.dataset._dataset_v2 import _GROUP_FORMAT_METADATA_KEY, _INDEX_ARRAY_KEY
 from polaris.dataset.zarr._manifest import generate_zarr_manifest
+
+# Helper methods
+
+
+def _check_column_b_or_c_data(data, idx):
+    return all(np.array_equal(data[prop], np.arange(32) + (32 * idx)) for prop in ["x", "y", "z"])
+
+
+def _check_column_a_data(data, idx):
+    return np.array_equal(data, np.arange(256) + (256 * idx))
+
+
+# Test cases
 
 
 def test_dataset_v2_get_columns(test_dataset_v2):
-    assert set(test_dataset_v2.columns) == {"A", "B"}
+    assert set(test_dataset_v2.columns) == {"A", "B", "C"}
 
 
 def test_dataset_v2_get_rows(test_dataset_v2):
     assert set(test_dataset_v2.rows) == set(range(100))
 
 
-def test_dataset_v2_get_data(test_dataset_v2, zarr_archive):
-    root = zarr.open(zarr_archive, "r")
+def test_dataset_v2_get_data(test_dataset_v2):
     indices = np.random.randint(0, len(test_dataset_v2), 5)
     for idx in indices:
-        assert np.array_equal(test_dataset_v2.get_data(row=idx, col="A"), root["A"][idx])
-        assert np.array_equal(test_dataset_v2.get_data(row=idx, col="B"), root["B"][idx])
+        assert _check_column_a_data(test_dataset_v2.get_data(row=idx, col="A"), idx)
+        assert _check_column_b_or_c_data(test_dataset_v2.get_data(row=idx, col="B"), idx)
+        assert _check_column_b_or_c_data(test_dataset_v2.get_data(row=idx, col="C"), idx)
 
 
-def test_dataset_v2_with_subset(test_dataset_v2, zarr_archive):
-    root = zarr.open(zarr_archive, "r")
+def test_dataset_v2_with_subset(test_dataset_v2):
     indices = np.random.randint(0, len(test_dataset_v2), 5)
-    subset = Subset(test_dataset_v2, indices, "A", "B")
+    subset = Subset(test_dataset_v2, indices, "A", ["B", "C"])
     for i, (x, y) in enumerate(subset):
-        idx = indices[i]
-        assert np.array_equal(x, root["A"][idx])
-        assert np.array_equal(y, root["B"][idx])
+        assert _check_column_a_data(x, indices[i])
+        assert _check_column_b_or_c_data(y["B"], indices[i])
+        assert _check_column_b_or_c_data(y["C"], indices[i])
 
 
 def test_dataset_v2_load_to_memory(test_dataset_v2):
@@ -47,7 +56,7 @@ def test_dataset_v2_load_to_memory(test_dataset_v2):
         dataset=test_dataset_v2,
         indices=range(100),
         input_cols=["A"],
-        target_cols=["B"],
+        target_cols=["B", "C"],
     )
 
     t1 = perf_counter()
@@ -70,8 +79,9 @@ def test_dataset_v2_serialization(test_dataset_v2, tmp_path):
     path = test_dataset_v2.to_json(save_dir)
     new_dataset = DatasetV2.from_json(path)
     for i in range(5):
-        assert np.array_equal(new_dataset.get_data(i, "A"), test_dataset_v2.get_data(i, "A"))
-        assert np.array_equal(new_dataset.get_data(i, "B"), test_dataset_v2.get_data(i, "B"))
+        assert _check_column_a_data(new_dataset.get_data(row=i, col="A"), i)
+        assert _check_column_b_or_c_data(new_dataset.get_data(row=i, col="B"), i)
+        assert _check_column_b_or_c_data(new_dataset.get_data(row=i, col="C"), i)
 
 
 def test_dataset_v2_caching(test_dataset_v2, tmp_path):
@@ -108,122 +118,75 @@ def test_dataset_v1_v2_compatibility(test_dataset, tmp_path):
         assert y1 == y2
 
 
-def test_dataset_v2_with_pdbs(pdb_paths, tmp_path):
-    # The PDB example is interesting because it creates a more complex Zarr archive
-    # that includes subgroups
-    zarr_root_path = str(tmp_path / "pdbs.zarr")
-    factory = DatasetFactory(zarr_root_path)
-
-    # Build a V1 dataset
-    converter = PDBConverter()
-    factory.register_converter("pdb", converter)
-    factory.add_from_files(pdb_paths, axis=0)
-    dataset_v1 = factory.build()
-
-    # Build a V2 dataset based on the V1 dataset
-
-    # Add the magic index column to the Zarr subgroup
-    root = zarr.open(zarr_root_path, "a")
-    ordered_keys = [v.split("/")[-1] for v in dataset_v1.table["pdb"].values]
-    root["pdb"].array(_INDEX_ARRAY_KEY, data=ordered_keys, dtype=object, object_codec=numcodecs.VLenUTF8())
-    zarr.consolidate_metadata(zarr_root_path)
-
-    # Update annotations to no longer have pointer columns
-    annotations = deepcopy(dataset_v1.annotations)
-    for anno in annotations.values():
-        anno.is_pointer = False
-
-    # Create the dataset
-    dataset_v2 = DatasetV2(
-        zarr_root_path=zarr_root_path,
-        annotations=annotations,
-        default_adapters=dataset_v1.default_adapters,
-    )
-
-    assert len(dataset_v1) == len(dataset_v2)
-    for idx in range(len(dataset_v1)):
-        pdb_1 = dataset_v1.get_data(idx, "pdb")
-        pdb_2 = dataset_v2.get_data(idx, "pdb")
-        assert pdb_1 == pdb_2
+def test_dataset_v2_with_pdbs(pdb_paths, tmp_path): ...
 
 
-def test_dataset_v2_indexing(zarr_archive):
-    # Create a subgroup with 100 arrays
-    root = zarr.open(zarr_archive, "a")
-    subgroup = root.create_group("X")
-    for i in range(100):
-        subgroup.array(f"{i}", data=np.array([i] * 100))
-
-    # Index it in reverse (element 0 is the last element in the array)
-    indices = [f"{idx}" for idx in range(100)][::-1]
-    subgroup.array(_INDEX_ARRAY_KEY, data=indices, dtype=object, object_codec=numcodecs.VLenUTF8())
-    zarr.consolidate_metadata(zarr_archive)
-
-    # Create the dataset
-    dataset = DatasetV2(zarr_root_path=zarr_archive)
-
-    # Check that the dataset is indexed correctly
-    for idx in range(100):
-        assert np.array_equal(dataset.get_data(row=idx, col="X"), np.array([99 - idx] * 100))
-
-
-def test_dataset_v2_validation_index_array(zarr_archive):
-    root = zarr.open(zarr_archive, "a")
+def test_dataset_v2_validation_index_array(zarr_archive_v2):
+    root = zarr.open(zarr_archive_v2, "a")
 
     # Create subgroup that lacks the index array
-    subgroup = root.create_group("X")
-    zarr.consolidate_metadata(zarr_archive)
+    subgroup = root.create_group("D")
+    subgroup.attrs[_GROUP_FORMAT_METADATA_KEY] = "subgroups"
+    zarr.consolidate_metadata(zarr_archive_v2)
 
     with pytest.raises(ValidationError, match="does not have an index array"):
-        DatasetV2(zarr_root_path=zarr_archive)
+        DatasetV2(zarr_root_path=zarr_archive_v2)
 
     indices = [f"{idx}" for idx in range(100)]
     indices[-1] = "invalid"
 
     # Create index array that doesn't match group length (zero arrays in group, but 100 indices)
     subgroup.array(_INDEX_ARRAY_KEY, data=indices, dtype=object, object_codec=numcodecs.VLenUTF8())
-    zarr.consolidate_metadata(zarr_archive)
+    zarr.consolidate_metadata(zarr_archive_v2)
 
     with pytest.raises(ValidationError, match="Length of index array"):
-        DatasetV2(zarr_root_path=zarr_archive)
+        DatasetV2(zarr_root_path=zarr_archive_v2)
 
     for i in range(100):
-        subgroup.array(f"{i}", data=np.random.random(100))
-    zarr.consolidate_metadata(zarr_archive)
+        subgroup.create_group(str(i))
+    zarr.consolidate_metadata(zarr_archive_v2)
 
     # Create index array that has invalid keys (last keys = 'invalid' rather than '99')
     with pytest.raises(ValidationError, match="Keys of index array"):
-        DatasetV2(zarr_root_path=zarr_archive)
+        DatasetV2(zarr_root_path=zarr_archive_v2)
 
 
-def test_dataset_v2_validation_consistent_lengths(zarr_archive):
-    root = zarr.open(zarr_archive, "a")
+def test_dataset_v2_validation_consistent_lengths(zarr_archive_v2):
+    root = zarr.open(zarr_archive_v2, "a")
 
     # Change the length of one of the arrays
-    root["A"].append(np.random.random((1, 2048)))
-    zarr.consolidate_metadata(zarr_archive)
+    root["A"].append(np.random.random((1, 256)))
+    zarr.consolidate_metadata(zarr_archive_v2)
 
     # Subgroup has a false number of indices
     with pytest.raises(ValidationError, match="should have the same length"):
-        DatasetV2(zarr_root_path=zarr_archive)
+        DatasetV2(zarr_root_path=zarr_archive_v2)
 
-    # Make the length of the two arrays equal again
-    # shouldn't crash
-    root["B"].append(np.random.random((1, 2048)))
-    zarr.consolidate_metadata(zarr_archive)
-    DatasetV2(zarr_root_path=zarr_archive)
+    # Make the length of the different columns equal again
+    subgroup = root["B"].create_group("100")
+    subgroup.array("x", data=np.arange(32))
+    subgroup.array("y", data=np.arange(32))
+    subgroup.array("z", data=np.arange(32))
+
+    # Directly appending a single element fails, likely because a bug in the Zarr Array API
+    root["B"][_INDEX_ARRAY_KEY] = root["B"][_INDEX_ARRAY_KEY][:].tolist() + [100]
+
+    root["C"]["x"].append(np.arange(32).reshape(1, 32))
+    root["C"]["y"].append(np.arange(32).reshape(1, 32))
+    root["C"]["z"].append(np.arange(32).reshape(1, 32))
+
+    zarr.consolidate_metadata(zarr_archive_v2)
+    DatasetV2(zarr_root_path=zarr_archive_v2)
 
     # Create subgroup with inconsistent length
-    subgroup = root.create_group("X")
-    for i in range(100):
-        subgroup.array(f"{i}", data=np.random.random(100))
-    indices = [f"{idx}" for idx in range(100)]
-    subgroup.array(_INDEX_ARRAY_KEY, data=indices, dtype=object, object_codec=numcodecs.VLenUTF8())
-    zarr.consolidate_metadata(zarr_archive)
+    subgroup = root.create_group("D")
+    subgroup.create_group("0")
+    subgroup.array(_INDEX_ARRAY_KEY, data=["0"], dtype=object, object_codec=numcodecs.VLenUTF8())
+    zarr.consolidate_metadata(zarr_archive_v2)
 
     # Subgroup has a false number of indices
     with pytest.raises(ValidationError, match="should have the same length"):
-        DatasetV2(zarr_root_path=zarr_archive)
+        DatasetV2(zarr_root_path=zarr_archive_v2)
 
 
 def test_zarr_manifest(test_dataset_v2):
@@ -231,17 +194,20 @@ def test_zarr_manifest(test_dataset_v2):
     assert test_dataset_v2.zarr_manifest_path is not None
     assert os.path.isfile(test_dataset_v2.zarr_manifest_path)
 
-    # Assert the manifest contains 204 rows (the number "204" is chosen because
-    # the Zarr archive defined in `conftest.py` contains 204 unique files)
+    # The root has 2 files (.zmetadata, .zgroup)
+    # The A array has 1 array with 100 chunks = 100 + 1 = 101
+    # The B group has 100 groups with 3 single-chunk arrays + 1 single-chunk array = 100 * (3 * 2 + 1) + 2 + 2 = 704
+    # The C group has 3 arrays with 100 chunks = 3 * (100 + 1) + 2 = 305
+    # Total number of files: 2 + 101 + 702 + 305 = 1112
     df = pd.read_parquet(test_dataset_v2.zarr_manifest_path)
-    assert len(df) == 204
+    assert len(df) == 1112
 
     # Assert the manifest hash is calculated
     assert test_dataset_v2.zarr_manifest_md5sum is not None
 
     # Add array to Zarr archive to change the number of chunks in the dataset
     root = zarr.open(test_dataset_v2.zarr_root_path, "a")
-    root.array("C", data=np.random.random((100, 2048)), chunks=(1, None))
+    root.array("D", data=np.random.random((100, 256)), chunks=(1, None))
 
     generate_zarr_manifest(test_dataset_v2.zarr_root_path, test_dataset_v2._cache_dir)
 
@@ -249,23 +215,37 @@ def test_zarr_manifest(test_dataset_v2):
     post_change_manifest_length = len(pd.read_parquet(test_dataset_v2.zarr_manifest_path))
 
     # Ensure Zarr manifest has an additional 100 chunks + 1 array metadata file
-    assert post_change_manifest_length == 305
+    assert post_change_manifest_length == 1213
 
 
-def test_dataset_v2__get_item__(test_dataset_v2, zarr_archive):
+def test_dataset_v2__get_item__(test_dataset_v2):
     """Test the __getitem__() interface for the dataset V2."""
 
-    # Ground truth
-    root = zarr.open(zarr_archive)
-
     # Get a specific cell
-    assert np.array_equal(test_dataset_v2[0, "A"], root["A"][0, :])
+    assert np.array_equal(test_dataset_v2[0, "A"], np.arange(256))
 
     # Get a specific row
-    def _check_row_equality(d1, d2):
+    def _check_dict_equality(d1, d2):
         assert len(d1) == len(d2)
-        for k in d1:
-            assert np.array_equal(d1[k], d2[k])
+        for k, v in d1.items():
+            if isinstance(v, dict):
+                _check_dict_equality(v, d2[k])
+            else:
+                assert np.array_equal(d1[k], d2[k])
 
-    _check_row_equality(test_dataset_v2[0], {"A": root["A"][0, :], "B": root["B"][0, :]})
-    _check_row_equality(test_dataset_v2[10], {"A": root["A"][10, :], "B": root["B"][10, :]})
+    _check_dict_equality(
+        test_dataset_v2[0],
+        {
+            "A": np.arange(256),
+            "B": {"x": np.arange(32), "y": np.arange(32), "z": np.arange(32)},
+            "C": {"x": np.arange(32), "y": np.arange(32), "z": np.arange(32)},
+        },
+    )
+    _check_dict_equality(
+        test_dataset_v2[10],
+        {
+            "A": np.arange(256) + 2560,
+            "B": {"x": np.arange(32) + 320, "y": np.arange(32) + 320, "z": np.arange(32) + 320},
+            "C": {"x": np.arange(32) + 320, "y": np.arange(32) + 320, "z": np.arange(32) + 320},
+        },
+    )


### PR DESCRIPTION
## Changelogs

- Add support for a new _group of arrays_ structure.

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [X] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

A popular file format in drug discovery to represent protein structures is the PDB (Protein Data Bank) file. The 3D structure of the protein can be thought of as a list of properties for each of the protein's atoms (e.g. the atom's x, y and z coordinate). For each of these properties, you can save all values in a single array. This is the internal representation of the popular [Biotite](https://www.biotite-python.org/) library, see e.g. [AtomArray](https://www.biotite-python.org/latest/apidoc/biotite.structure.AtomArray.html). In Zarr, a group of arrays thus makes for a natural representation for this data.

There are 14 properties and we need at least 3 files per property (i.e. the chunk, .zattrs, .zmetadata). With some extra metadata files on the group level, that makes for 44 files per protein. All of these files are small. For cloud-native Zarr archives, this makes the Zarr based solution a lot less performant than simply saving a single PDB file.

The primary alternative that comes to mind is to restructure the Zarr archive such that the arrays are larger.

The main idea is to concatenate the per-group arrays in one larger array. Since the per-group arrays are variable in size (i.e. the number of atoms per protein differs), we would use [Ragged Arrays](https://zarr.readthedocs.io/en/stable/tutorial.html#ragged-arrays). This PR adds support for a new structure that allows us to built a datapoint from indexing the nth element in each array.

We now officially support three Zarr structures to represent the data in a column: 
- An array: Each element in the array corresponds to a data point in the dataset.
- A group of groups: Each subgroup corresponds to a data point in the dataset.
  - The special `__index__` array specifies the ordering of the subgroups.
- A group of arrays **(new)**: The nth datapoint is constructed from indexing the nth element in each array.
