### PR TITLE
fix: Pin Boto3 version to avoid breaking change

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -13,7 +13,7 @@ dependencies:
   - fsspec
   - yaspin
   - typing-extensions >=4.12.0
-  - boto3 >=1.35.0
+  - boto3 <1.36.0
   - pyroaring
 
   # Hub client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "authlib",
-    "boto3>=1.35.0",
+    "boto3 <1.36.0",
     "datamol >=0.12.1",
     "fastpdb",
     "fsspec[http]",

--- a/uv.lock
+++ b/uv.lock
@@ -317,30 +317,30 @@ css = [
 
 [[package]]
 name = "boto3"
-version = "1.35.98"
+version = "1.35.99"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/5b/60bf8560df0688ea97098c935a5ecdd595e742891ed5e85ebe7257a0ee5d/boto3-1.35.98.tar.gz", hash = "sha256:4b6274b4fe9d7113f978abea66a1f20c8a397c268c9d1b2a6c96b14a256da4a5", size = 110996 }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/99/3e8b48f15580672eda20f33439fc1622bd611f6238b6d05407320e1fb98c/boto3-1.35.99.tar.gz", hash = "sha256:e0abd794a7a591d90558e92e29a9f8837d25ece8e3c120e530526fe27eba5fca", size = 111028 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/e4/e0aba5c388e189a145d13699f59e2ec71600eab0bd545f412d94c130e183/boto3-1.35.98-py3-none-any.whl", hash = "sha256:d0224e1499d7189b47aa7f469d96522d98df6f5702fccb20a95a436582ebcd9d", size = 139180 },
+    { url = "https://files.pythonhosted.org/packages/65/77/8bbca82f70b062181cf0ae53fd43f1ac6556f3078884bfef9da2269c06a3/boto3-1.35.99-py3-none-any.whl", hash = "sha256:83e560faaec38a956dfb3d62e05e1703ee50432b45b788c09e25107c5058bd71", size = 139178 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.35.98"
+version = "1.35.99"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/af/081b065f46ecb9a930a1964d1b7d275e408a03cb45ff7cd89128481dc986/botocore-1.35.98.tar.gz", hash = "sha256:d11742b3824bdeac3c89eeeaf5132351af41823bbcef8fc15e95c8250b1de09c", size = 13489772 }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/9c/1df6deceee17c88f7170bad8325aa91452529d683486273928eecfd946d8/botocore-1.35.99.tar.gz", hash = "sha256:1eab44e969c39c5f3d9a3104a0836c24715579a455f12b3979a31d7cde51b3c3", size = 13490969 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d5/bb969f907b17e03f8169df1e5c548d6719115f1a1386529c6f8776100fb0/botocore-1.35.98-py3-none-any.whl", hash = "sha256:4f1c0b687488663a774ad3a5e81a5f94fae1bcada2364cfdc48482c4dbf794d5", size = 13291578 },
+    { url = "https://files.pythonhosted.org/packages/fc/dd/d87e2a145fad9e08d0ec6edcf9d71f838ccc7acdd919acc4c0d4a93515f8/botocore-1.35.99-py3-none-any.whl", hash = "sha256:b22d27b6b617fc2d7342090d6129000af2efd20174215948c0d7ae2da0fab445", size = 13293216 },
 ]
 
 [[package]]
@@ -2212,7 +2212,7 @@ wheels = [
 
 [[package]]
 name = "polaris-lib"
-version = "0.11.1.dev1+ga807434.d20250114"
+version = "0.11.1.dev2+gf358bf2.d20250116"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -2269,7 +2269,7 @@ doc = [
 [package.metadata]
 requires-dist = [
     { name = "authlib" },
-    { name = "boto3", specifier = ">=1.35.0" },
+    { name = "boto3", specifier = "<1.36.0" },
     { name = "datamol", specifier = ">=0.12.1" },
     { name = "fastpdb" },
     { name = "fsspec", extras = ["http"] },


### PR DESCRIPTION
## Changelogs

- Pin Boto3 to < 1.36.0, to avoid a breaking change in the checksum request headers

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

Fixes #246.

Boto3 has changed its [default behavior in 1.36.0](https://github.com/boto/boto3/issues/4392). The header that is now added automatically is not supported by all S3-compatible services, such as Cloudflare R2, which is the backing store for the Polaris Hub storage. The suggested configuration to disable the new behavior does not appear to fix this issue in our case. I've elected to pin the Boto3 version for now.
