### PR TITLE
fix: Replace yaspin with halo for spinners

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -11,7 +11,7 @@ dependencies:
   - pydantic >=2
   - pydantic-settings >=2
   - fsspec
-  - yaspin
+  - halo
   - typing-extensions >=4.12.0
   - boto3 <1.36.0
   - pyroaring

--- a/polaris/utils/context.py
+++ b/polaris/utils/context.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
-from yaspin import yaspin
-from yaspin.spinners import Spinners
+from halo import Halo
 
 from polaris.mixins import FormattingMixin
 
@@ -23,7 +22,7 @@ class ProgressIndicator(FormattingMixin):
         self._success_msg = success_msg
         self._error_msg = error_msg
 
-        self._spinner = yaspin(Spinners.dots, text=self._start_msg)
+        self._spinner = Halo(text=self._start_msg, spinner="dots")
 
     def __enter__(self):
         self._spinner.start()
@@ -33,9 +32,11 @@ class ProgressIndicator(FormattingMixin):
         self._spinner.text = ""
 
         if exc_type:
-            self._spinner.red.fail(f"💥 ERROR: {self._error_msg}")
+            self._spinner.text_color = "red"
+            self._spinner.fail(f"ERROR: {self._error_msg}")
         else:
-            self._spinner.green.ok(f"✅ SUCCESS: {self.format(self._success_msg, self.BOLD)}\n")
+            self._spinner.text_color = "green"
+            self._spinner.succeed(f"SUCCESS: {self.format(self._success_msg, self.BOLD)}\n")
 
         self._spinner.stop()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "tqdm",
     "typer",
     "typing-extensions>=4.12.0",
-    "yaspin",
+    "halo",
     "zarr >=2,<3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -891,6 +891,19 @@ wheels = [
 ]
 
 [[package]]
+name = "halo"
+version = "0.0.31"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "log-symbols" },
+    { name = "six" },
+    { name = "spinners" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/48/d53580d30b1fabf25d0d1fcc3f5b26d08d2ac75a1890ff6d262f9f027436/halo-0.0.31.tar.gz", hash = "sha256:7b67a3521ee91d53b7152d4ee3452811e1d2a6321975137762eb3d70063cc9d6", size = 11666 }
+
+[[package]]
 name = "httpcore"
 version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -993,7 +1006,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1402,6 +1415,18 @@ wheels = [
 ]
 
 [[package]]
+name = "log-symbols"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/87/e86645d758a4401c8c81914b6a88470634d1785c9ad09823fa4a1bd89250/log_symbols-0.0.14.tar.gz", hash = "sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556", size = 3211 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/5d/d710c38be68b0fb54e645048fe359c3904cc3cb64b2de9d40e1712bf110c/log_symbols-0.0.14-py3-none-any.whl", hash = "sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca", size = 3081 },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1616,7 +1641,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -2212,7 +2237,7 @@ wheels = [
 
 [[package]]
 name = "polaris-lib"
-version = "0.11.2.dev0+g6a96b94.d20250117"
+version = "0.11.3.dev0+g817f3a5.d20250118"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -2220,6 +2245,7 @@ dependencies = [
     { name = "datamol" },
     { name = "fastpdb" },
     { name = "fsspec", extra = ["http"] },
+    { name = "halo" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "numcodecs", version = "0.13.1", source = { registry = "https://pypi.org/simple" }, extra = ["msgpack"], marker = "python_full_version < '3.11'" },
@@ -2237,7 +2263,6 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
     { name = "typing-extensions" },
-    { name = "yaspin" },
     { name = "zarr" },
 ]
 
@@ -2273,6 +2298,7 @@ requires-dist = [
     { name = "datamol", specifier = ">=0.12.1" },
     { name = "fastpdb" },
     { name = "fsspec", extras = ["http"] },
+    { name = "halo" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "numcodecs", extras = ["msgpack"], specifier = ">=0.13.1" },
@@ -2289,7 +2315,6 @@ requires-dist = [
     { name = "tqdm" },
     { name = "typer" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
-    { name = "yaspin" },
     { name = "zarr", specifier = ">=2,<3" },
 ]
 
@@ -3234,6 +3259,15 @@ wheels = [
 ]
 
 [[package]]
+name = "spinners"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/91/bb331f0a43e04d950a710f402a0986a54147a35818df0e1658551c8d12e1/spinners-0.0.24.tar.gz", hash = "sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f", size = 5308 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/8e/3310207a68118000ca27ac878b8386123628b335ecb3d4bec4743357f0d1/spinners-0.0.24-py3-none-any.whl", hash = "sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98", size = 5499 },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3343,7 +3377,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
@@ -3592,18 +3626,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/e3/924c3f64b6b3077889df9a1ece1ed8947e7b61b0a933f2ec93041990a677/yarl-1.18.3-cp312-cp312-win32.whl", hash = "sha256:f91c4803173928a25e1a55b943c81f55b8872f0018be83e3ad4938adffb77dd2", size = 84097 },
     { url = "https://files.pythonhosted.org/packages/34/45/0e055320daaabfc169b21ff6174567b2c910c45617b0d79c68d7ab349b02/yarl-1.18.3-cp312-cp312-win_amd64.whl", hash = "sha256:7e2ee16578af3b52ac2f334c3b1f92262f47e02cc6193c598502bd46f5cd1477", size = 90399 },
     { url = "https://files.pythonhosted.org/packages/f5/4b/a06e0ec3d155924f77835ed2d167ebd3b211a7b0853da1cf8d8414d784ef/yarl-1.18.3-py3-none-any.whl", hash = "sha256:b57f4f58099328dfb26c6a771d09fb20dbbae81d20cfb66141251ea063bd101b", size = 45109 },
-]
-
-[[package]]
-name = "yaspin"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "termcolor" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/3c/70df5034e6712fcc238b76f6afd1871de143a2a124d80ae2c377cde180f3/yaspin-3.1.0.tar.gz", hash = "sha256:7b97c7e257ec598f98cef9878e038bfa619ceb54ac31d61d8ead2b3128f8d7c7", size = 36791 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/78/fa25b385d9f2c406719b5cf574a0980f5ccc6ea1f8411d56249f44acd3c2/yaspin-3.1.0-py3-none-any.whl", hash = "sha256:5e3d4dfb547d942cae6565718123f1ecfa93e745b7e51871ad2bbae839e71b73", size = 18629 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changelogs

- Switched from `yaspin` to `Halo` for terminal spinners to fix issues with small terminal widths and improve overall reliability. [Halo](https://github.com/manrajgrover/halo) handles text better and avoids truncation errors.

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
