### PR TITLE
Chore: Remove duplicate and unused CompetitionPredictions class

### DIFF
--- a/polaris/evaluate/_results.py
+++ b/polaris/evaluate/_results.py
@@ -12,7 +12,7 @@ from pydantic import (
 )
 from pydantic.alias_generators import to_camel
 
-from polaris.evaluate import ResultsMetadata, BenchmarkPredictions
+from polaris.evaluate import ResultsMetadata
 from polaris.utils.errors import InvalidResultError
 from polaris.utils.misc import slugify
 from polaris.utils.types import (
@@ -197,18 +197,3 @@ class CompetitionResults(EvaluationResult):
     @property
     def competition_artifact_id(self) -> str:
         return f"{self.competition_owner}/{slugify(self.competition_name)}"
-
-
-class CompetitionPredictions(ResultsMetadata, BenchmarkPredictions):
-    """
-    Predictions for competition benchmarks.
-
-    This object is to be used as input to [`CompetitionSpecification.evaluate`][polaris.competition.CompetitionSpecification.evaluate].
-    It is used to ensure that the structure of the predictions are compatible with evaluation methods on the Polaris Hub.
-    In addition to the predictions, it contains additional meta-data to create a results object.
-
-    Attributes:
-        access: The access the returned results should have
-    """
-
-    access: AccessType = "private"


### PR DESCRIPTION
## Changelogs

- Removed the duplicate `CompetitionPredictions` class

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

We use [`polaris.evaluate._predictions.CompetitionPredictions`](https://github.com/polaris-hub/polaris/blob/main/polaris/evaluate/_predictions.py#L252), we also had [`polaris.evaluate._results.CompetitionPredictions`](https://github.com/polaris-hub/polaris/blob/main/polaris/evaluate/_results.py#L202). Since the latter wasn't used, I deleted it.
