### PR TITLE
`Subset.as_dataframe()` hides targets instead of raising an error

### DIFF
--- a/polaris/dataset/_subset.py
+++ b/polaris/dataset/_subset.py
@@ -200,16 +200,19 @@ class Subset:
             This method loads the entire dataset in memory.
         """
         # Create an empty dataframe
-        cols = self.input_cols + self.target_cols
+        cols = self.input_cols
+        if not self._hide_targets:
+            cols += self.target_cols
         df = pd.DataFrame(columns=cols)
 
         # Fill the dataframe
-        targets = self.targets
-        if not self.is_multi_task:
-            targets = {self.target_cols[0]: targets}
+        if not self._hide_targets:
+            targets = self.targets
+            if not self.is_multi_task:
+                targets = {self.target_cols[0]: targets}
 
-        for k in targets:
-            df[k] = targets[k]
+            for k in targets:
+                df[k] = targets[k]
 
         inputs = self.inputs
         if not self.is_multi_input:

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1,5 +1,6 @@
 import datamol as dm
 import numpy as np
+import pandas as pd
 import pytest
 
 from polaris.dataset import Subset
@@ -51,6 +52,14 @@ def test_access_to_test_set(test_single_task_benchmark):
     # For the train set it should work
     assert all(isinstance(y, float) for x, y in train)
     assert all(isinstance(train[i][1], float) for i in range(len(train)))
+
+    # as_dataframe should work for both, but contain no targets for test
+    train_df = train.as_dataframe()
+    assert isinstance(train_df, pd.DataFrame)
+    assert "expt" in train_df.columns
+    test_df = test.as_dataframe()
+    assert isinstance(test_df, pd.DataFrame)
+    assert "expt" not in test_df.columns
 
 
 def test_input_featurization(test_single_task_benchmark):


### PR DESCRIPTION


## Changelogs

- `Subset.as_dataframe()` would raise an error when called on a test set (which hides its targets), this PR allows method to work, just doesn't return targest

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

Resolves https://github.com/polaris-hub/polaris/issues/257
