### PR TITLE
Fix: Always pass bytes in the RDKitMolCodec

### DIFF
--- a/polaris/dataset/zarr/codecs.py
+++ b/polaris/dataset/zarr/codecs.py
@@ -22,12 +22,14 @@ class RDKitMolCodec(VLenBytes):
         """
         Encode a chunk of RDKit Mols to byte strings
         """
+        # NOTE (cwognum): I ran into a Cython issue because we could pass None to the VLenBytes codec.
+        # Using np.full() ensures all elements are initialized as empty byte strings instead.
         to_encode = np.full(fill_value=b"", shape=len(buf), dtype=object)
         for idx, mol in enumerate(buf):
             if mol is None or (isinstance(mol, bytes) and len(mol) == 0):
                 continue
             if not isinstance(mol, Chem.Mol):
-                raise ValueError(f"Expected an RDKitMol, but got {type(buf)} instead.")
+                raise ValueError(f"Expected an RDKitMol, but got {type(mol)} instead.")
             props = Chem.PropertyPickleOptions.AllProps
             to_encode[idx] = mol.ToBinary(props)
 

--- a/polaris/dataset/zarr/codecs.py
+++ b/polaris/dataset/zarr/codecs.py
@@ -22,7 +22,7 @@ class RDKitMolCodec(VLenBytes):
         """
         Encode a chunk of RDKit Mols to byte strings
         """
-        to_encode = np.empty(shape=len(buf), dtype=object)
+        to_encode = np.full(fill_value=b"", shape=len(buf), dtype=object)
         for idx, mol in enumerate(buf):
             if mol is None or (isinstance(mol, bytes) and len(mol) == 0):
                 continue

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -6,6 +6,13 @@ from polaris.dataset.zarr.codecs import RDKitMolCodec
 
 def test_rdkit_mol_codec():
     mol = dm.to_mol("C1=CC=CC=C1")
-    arr = zarr.array([mol, mol], chunks=(2,), dtype=object, object_codec=RDKitMolCodec())
+
+    arr = zarr.empty(shape=10, chunks=2, dtype=object, object_codec=RDKitMolCodec())
+
+    arr[0] = mol
+    arr[1] = mol
+    arr[2] = mol
+
     assert dm.same_mol(arr[0], mol)
     assert dm.same_mol(arr[1], mol)
+    assert dm.same_mol(arr[2], mol)


### PR DESCRIPTION
## Changelogs

- Always pass bytes to the `VLenBytes` codec, parent class of the `RDKitMolCodec`.

---

_Checklist:_

- [ ] ~_Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._~
- [X] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [X] _Update the API documentation if a new function is added, or an existing one is deleted._
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

I was running into a Cython issue with a chunk size > 1 because we were passing None rather than bytes.