### PR TITLE
feat: Artifact Versioning - upload benchmark

### DIFF
--- a/docs/tutorials/create_a_benchmark.ipynb
+++ b/docs/tutorials/create_a_benchmark.ipynb
@@ -238,6 +238,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If you want to upload a new version of your benchmark, you can specify its previous version with the `parent_artifact_id` parameter. Don't forget to add a changelog describing your updates!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "benchmark.artifact_changelog = \"In this version, I added...\"\n",
+    "\n",
+    "benchmark.upload_to_hub(\n",
+    "  owner=\"your-username\",\n",
+    "  parent_artifact_id=\"your-username/my-first-benchmark\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "---\n",
     "The End."
    ]

--- a/docs/tutorials/create_a_dataset.ipynb
+++ b/docs/tutorials/create_a_dataset.ipynb
@@ -336,6 +336,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If you want to upload a new version of your dataset, you can specify its previous version with the `parent_artifact_id` parameter. Don't forget to add a changelog describing your updates!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.artifact_changelog = \"In this version, I added...\"\n",
+    "\n",
+    "dataset.upload_to_hub(\n",
+    "  owner=\"your-username\",\n",
+    "  parent_artifact_id=\"your-username/tutorial-example\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Advanced: Optimization\n",
     "In this tutorial, we only briefly touched on the high-level concepts that need to be understood to create a Polaris compatible dataset using Zarr. However, Zarr has a lot more to offer and tweaking the settings **can drastically improve storage or data access efficiency.**\n",
     "\n",

--- a/polaris/_artifact.py
+++ b/polaris/_artifact.py
@@ -63,7 +63,7 @@ class BaseArtifactModel(BaseModel):
         if val is None:
             if info.data.get("name") is not None:
                 return slugify(info.data.get("name"))
-            return val
+        return val
 
     @computed_field
     @property

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -216,6 +216,7 @@ class BenchmarkSpecification(
         cache_auth_token: bool = True,
         access: AccessType = "private",
         owner: HubOwner | str | None = None,
+        parent_artifact_id: str | None = None,
         **kwargs: dict,
     ):
         """
@@ -229,7 +230,9 @@ class BenchmarkSpecification(
             cache_auth_token=cache_auth_token,
             **kwargs,
         ) as client:
-            return client.upload_benchmark(self, access=access, owner=owner)
+            return client.upload_benchmark(
+                self, access=access, owner=owner, parent_artifact_id=parent_artifact_id
+            )
 
     def to_json(self, destination: str) -> str:
         """Save the benchmark to a destination directory as a JSON file.

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -115,6 +115,8 @@ class BenchmarkSpecification(
         readme: Markdown text that can be used to provide a formatted description of the benchmark.
             If using the Polaris Hub, it is worth noting that this field is more easily edited through the Hub UI
             as it provides a rich text editor for writing markdown.
+        artifact_version: The version of the benchmark.
+        artifact_changelog: A description of the changes made in this benchmark version.
     For additional meta-data attributes, see the base classes.
     """
 
@@ -122,6 +124,10 @@ class BenchmarkSpecification(
 
     dataset: BaseDataset = Field(exclude=True)
     readme: str = ""
+
+    # Version-related fields
+    artifact_version: int = 1
+    artifact_changelog: str | None = None
 
     @computed_field
     @property

--- a/polaris/dataset/_base.py
+++ b/polaris/dataset/_base.py
@@ -302,7 +302,12 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def upload_to_hub(self, access: AccessType = "private", owner: HubOwner | str | None = None):
+    def upload_to_hub(
+        self,
+        access: AccessType = "private",
+        owner: HubOwner | str | None = None,
+        parent_artifact_id: str | None = None,
+    ):
         """Uploads the dataset to the Polaris Hub."""
         raise NotImplementedError
 

--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -218,7 +218,12 @@ class DatasetV1(BaseDataset, ChecksumMixin):
 
         return arr
 
-    def upload_to_hub(self, access: AccessType = "private", owner: HubOwner | str | None = None):
+    def upload_to_hub(
+        self,
+        access: AccessType = "private",
+        owner: HubOwner | str | None = None,
+        parent_artifact_id: str | None = None,
+    ):
         """
         Very light, convenient wrapper around the
         [`PolarisHubClient.upload_dataset`][polaris.hub.client.PolarisHubClient.upload_dataset] method.
@@ -226,7 +231,7 @@ class DatasetV1(BaseDataset, ChecksumMixin):
         from polaris.hub.client import PolarisHubClient
 
         with PolarisHubClient() as client:
-            client.upload_dataset(self, owner=owner, access=access)
+            client.upload_dataset(self, owner=owner, access=access, parent_artifact_id=parent_artifact_id)
 
     @classmethod
     def from_json(cls, path: str):

--- a/polaris/dataset/_dataset_v2.py
+++ b/polaris/dataset/_dataset_v2.py
@@ -192,7 +192,12 @@ class DatasetV2(BaseDataset):
 
         return arr
 
-    def upload_to_hub(self, access: AccessType = "private", owner: HubOwner | str | None = None):
+    def upload_to_hub(
+        self,
+        access: AccessType = "private",
+        owner: HubOwner | str | None = None,
+        parent_artifact_id: str | None = None,
+    ):
         """
         Uploads the dataset to the Polaris Hub.
         """
@@ -200,7 +205,7 @@ class DatasetV2(BaseDataset):
         from polaris.hub.client import PolarisHubClient
 
         with PolarisHubClient() as client:
-            client.upload_dataset(self, owner=owner, access=access)
+            client.upload_dataset(self, owner=owner, access=access, parent_artifact_id=parent_artifact_id)
 
     @classmethod
     def from_json(cls, path: str):

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -638,6 +638,9 @@ class PolarisHubClient(OAuth2Client):
             )
 
             inserted_dataset = response.json()
+
+            # We modify the slug in the server
+            # Update dataset.slug here so dataset.urn is constructed correctly
             dataset.slug = inserted_dataset["slug"]
 
             with StorageSession(self, "write", dataset.urn) as storage:
@@ -703,6 +706,9 @@ class PolarisHubClient(OAuth2Client):
             )
 
             inserted_dataset = response.json()
+
+            # We modify the slug in the server
+            # Update dataset.slug here so dataset.urn is constructed correctly
             dataset.slug = inserted_dataset["slug"]
 
             with StorageSession(self, "write", dataset.urn) as storage:
@@ -744,7 +750,7 @@ class PolarisHubClient(OAuth2Client):
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
-        """Upload the benchmark to the Polaris Hub.
+        """Upload a benchmark to the Polaris Hub.
 
         Info: Owner
             You have to manually specify the owner in the benchmark data model. Because the owner could
@@ -779,27 +785,8 @@ class PolarisHubClient(OAuth2Client):
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
-        """Upload a benchmark to the Polaris Hub.
-
-        Info: Owner
-            You have to manually specify the owner in the benchmark data model. Because the owner could
-            be a user or an organization, we cannot automatically infer this from the logged-in user.
-
-        Note: Required meta-data
-            The Polaris client and hub maintain different requirements as to which meta-data is required.
-            The requirements by the hub are stricter, so when uploading to the hub you might
-            get some errors on missing meta-data. Make sure to fill-in as much of the meta-data as possible
-            before uploading.
-
-        Note: Non-existent datasets
-            The client will _not_ upload the associated dataset to the hub if it does not yet exist.
-            Make sure to specify an existing dataset or upload the dataset first.
-
-        Args:
-            benchmark: The benchmark to upload.
-            access: Grant public or private access to result
-            owner: Which Hub user or organization owns the artifact. Takes precedence over `benchmark.owner`.
-            parent_artifact_id: The `owner/slug` of the parent benchmark, if uploading a new version of a benchmark.
+        """
+        Upload a V1 benchmark to the Polaris Hub.
         """
         with track_progress(description="Uploading benchmark", total=1) as (progress, task):
             # Get the serialized data-model
@@ -826,6 +813,9 @@ class PolarisHubClient(OAuth2Client):
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
+        """
+        Upload a V2 benchmark to the Polaris Hub.
+        """
         with track_progress(description="Uploading benchmark", total=1) as (progress, task):
             # Get the serialized data-model
             # We exclude the dataset as we expect it to exist on the hub already.
@@ -849,8 +839,11 @@ class PolarisHubClient(OAuth2Client):
                 },
             )
 
-            uploaded_benchmark = response.json()
-            benchmark.slug = uploaded_benchmark["slug"]
+            inserted_benchmark = response.json()
+
+            # We modify the slug in the server
+            # Update benchmark.slug here so benchmark.urn is constructed correctly
+            benchmark.slug = inserted_benchmark["slug"]
 
             with StorageSession(self, "write", benchmark.urn) as storage:
                 logger.info("Copying the benchmark split to the Hub. This may take a while.")

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -540,7 +540,7 @@ class PolarisHubClient(OAuth2Client):
         timeout: TimeoutTypes = (10, 200),
         owner: HubOwner | str | None = None,
         if_exists: ZarrConflictResolution = "replace",
-        parent_slug: str | None = None,
+        parent_artifact_id: str | None = None,
     ):
         """Upload a dataset to the Polaris Hub.
 
@@ -565,7 +565,7 @@ class PolarisHubClient(OAuth2Client):
             owner: Which Hub user or organization owns the artifact. Takes precedence over `dataset.owner`.
             if_exists: Action for handling existing files in the Zarr archive. Options are 'raise' to throw
                 an error, 'replace' to overwrite, or 'skip' to proceed without altering the existing files.
-            parent_slug: The slug of the parent dataset, if uploading a new version of a dataset.
+            parent_artifact_id: The artifact id of the parent dataset, if uploading a new version of a dataset.
         """
         # Normalize timeout
         if timeout is None:
@@ -578,9 +578,9 @@ class PolarisHubClient(OAuth2Client):
             )
 
         if isinstance(dataset, DatasetV1):
-            self._upload_v1_dataset(dataset, timeout, access, owner, if_exists, parent_slug)
+            self._upload_v1_dataset(dataset, timeout, access, owner, if_exists, parent_artifact_id)
         elif isinstance(dataset, DatasetV2):
-            self._upload_v2_dataset(dataset, timeout, access, owner, if_exists, parent_slug)
+            self._upload_v2_dataset(dataset, timeout, access, owner, if_exists, parent_artifact_id)
 
     def _upload_v1_dataset(
         self,
@@ -589,7 +589,7 @@ class PolarisHubClient(OAuth2Client):
         access: AccessType,
         owner: HubOwner | str | None,
         if_exists: ZarrConflictResolution,
-        parent_slug: str | None,
+        parent_artifact_id: str | None,
     ):
         """
         Upload a V1 dataset to the Polaris Hub.
@@ -631,7 +631,7 @@ class PolarisHubClient(OAuth2Client):
                     },
                     "zarrContent": [md5sum.model_dump() for md5sum in dataset._zarr_md5sum_manifest],
                     "access": access,
-                    "parentSlug": parent_slug,
+                    "parentArtifactId": parent_artifact_id,
                     **dataset_json,
                 },
                 timeout=timeout,
@@ -675,7 +675,7 @@ class PolarisHubClient(OAuth2Client):
         access: AccessType,
         owner: HubOwner | str | None,
         if_exists: ZarrConflictResolution,
-        parent_slug: str | None,
+        parent_artifact_id: str | None,
     ):
         """
         Upload a V2 dataset to the Polaris Hub.
@@ -696,7 +696,7 @@ class PolarisHubClient(OAuth2Client):
                         "md5Sum": dataset.zarr_manifest_md5sum,
                     },
                     "access": access,
-                    "parentSlug": parent_slug,
+                    "parentArtifactId": parent_artifact_id,
                     **dataset_json,
                 },
                 timeout=timeout,
@@ -742,7 +742,7 @@ class PolarisHubClient(OAuth2Client):
         benchmark: BenchmarkV1Specification | BenchmarkV2Specification,
         access: AccessType = "private",
         owner: HubOwner | str | None = None,
-        parent_slug: str | None = None,
+        parent_artifact_id: str | None = None,
     ):
         """Upload the benchmark to the Polaris Hub.
 
@@ -764,20 +764,20 @@ class PolarisHubClient(OAuth2Client):
             benchmark: The benchmark to upload.
             access: Grant public or private access to result
             owner: Which Hub user or organization owns the artifact. Takes precedence over `benchmark.owner`.
-            parent_slug: The slug of the parent benchmark, if uploading a new version of a benchmark.
+            parent_artifact_id: The artifact id of the parent benchmark, if uploading a new version of a benchmark.
         """
         match benchmark:
             case BenchmarkV1Specification():
-                self._upload_v1_benchmark(benchmark, access, owner, parent_slug)
+                self._upload_v1_benchmark(benchmark, access, owner, parent_artifact_id)
             case BenchmarkV2Specification():
-                self._upload_v2_benchmark(benchmark, access, owner, parent_slug)
+                self._upload_v2_benchmark(benchmark, access, owner, parent_artifact_id)
 
     def _upload_v1_benchmark(
         self,
         benchmark: BenchmarkV1Specification,
         access: AccessType = "private",
         owner: HubOwner | str | None = None,
-        parent_slug: str | None = None,
+        parent_artifact_id: str | None = None,
     ):
         """Upload a benchmark to the Polaris Hub.
 
@@ -799,7 +799,7 @@ class PolarisHubClient(OAuth2Client):
             benchmark: The benchmark to upload.
             access: Grant public or private access to result
             owner: Which Hub user or organization owns the artifact. Takes precedence over `benchmark.owner`.
-            parent_slug: The slug of the parent benchmark, if uploading a new version of a benchmark.
+            parent_artifact_id: The artifact id of the parent benchmark, if uploading a new version of a benchmark.
         """
         with track_progress(description="Uploading benchmark", total=1) as (progress, task):
             # Get the serialized data-model
@@ -811,7 +811,7 @@ class PolarisHubClient(OAuth2Client):
 
             url = f"/v1/benchmark/{benchmark.artifact_id}"
             response = self._base_request_to_hub(
-                url=url, method="PUT", json={"parentSlug": parent_slug, **benchmark_json}
+                url=url, method="PUT", json={"parentArtifactId": parent_artifact_id, **benchmark_json}
             )
 
             benchmark_url = urljoin(self.settings.hub_url, response.headers.get("Content-Location"))
@@ -824,7 +824,7 @@ class PolarisHubClient(OAuth2Client):
         benchmark: BenchmarkV2Specification,
         access: AccessType = "private",
         owner: HubOwner | str | None = None,
-        parent_slug: str | None = None,
+        parent_artifact_id: str | None = None,
     ):
         with track_progress(description="Uploading benchmark", total=1) as (progress, task):
             # Get the serialized data-model
@@ -844,7 +844,7 @@ class PolarisHubClient(OAuth2Client):
                 json={
                     "access": access,
                     "datasetArtifactId": benchmark.dataset.artifact_id,
-                    "parentSlug": parent_slug,
+                    "parentArtifactId": parent_artifact_id,
                     **benchmark_json,
                 },
             )

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -565,7 +565,7 @@ class PolarisHubClient(OAuth2Client):
             owner: Which Hub user or organization owns the artifact. Takes precedence over `dataset.owner`.
             if_exists: Action for handling existing files in the Zarr archive. Options are 'raise' to throw
                 an error, 'replace' to overwrite, or 'skip' to proceed without altering the existing files.
-            parent_artifact_id: The artifact id of the parent dataset, if uploading a new version of a dataset.
+            parent_artifact_id: The `owner/slug` of the parent dataset, if uploading a new version of a dataset.
         """
         # Normalize timeout
         if timeout is None:
@@ -764,7 +764,7 @@ class PolarisHubClient(OAuth2Client):
             benchmark: The benchmark to upload.
             access: Grant public or private access to result
             owner: Which Hub user or organization owns the artifact. Takes precedence over `benchmark.owner`.
-            parent_artifact_id: The artifact id of the parent benchmark, if uploading a new version of a benchmark.
+            parent_artifact_id: The `owner/slug` of the parent benchmark, if uploading a new version of a benchmark.
         """
         match benchmark:
             case BenchmarkV1Specification():
@@ -799,7 +799,7 @@ class PolarisHubClient(OAuth2Client):
             benchmark: The benchmark to upload.
             access: Grant public or private access to result
             owner: Which Hub user or organization owns the artifact. Takes precedence over `benchmark.owner`.
-            parent_artifact_id: The artifact id of the parent benchmark, if uploading a new version of a benchmark.
+            parent_artifact_id: The `owner/slug` of the parent benchmark, if uploading a new version of a benchmark.
         """
         with track_progress(description="Uploading benchmark", total=1) as (progress, task):
             # Get the serialized data-model


### PR DESCRIPTION
## Changelogs

- Added version fields `artifact_version` and `artifact_changelog` to benchmarks
- `upload_benchmark` accepts an optional parameter `parent_artifact_id` (owner/slug), which defaults to None
  - The benchmark will be uploaded as a subsequent version of the provided parent
  - This functionality is different from the previous `upload_as_new_version` param implemented in `feat/artifact-versioning`, and `upload_datasets` has been updated accordingly
- Modified dataset and benchmark `upload_to_hub` functions to also accept `parent_artifact_id`
- Added info about `parent_artifact_id` and uploading new versions of datasets and benchmarks to the documentation
<img src="https://github.com/user-attachments/assets/ee83f0cd-16d8-4e1c-8039-561b1dafd3e3" />
<img src="https://github.com/user-attachments/assets/9e1ac285-d3ac-4bd9-b389-83c6b2b12a00" height="300px" />


---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs above._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
