### PR TITLE
Client: Model artifact remaining changes

### DIFF
--- a/docs/tutorials/create_a_dataset.ipynb
+++ b/docs/tutorials/create_a_dataset.ipynb
@@ -42,7 +42,7 @@
     "        ),\n",
     "        \"Permeability\": ColumnAnnotation(\n",
     "            description=\"MDR1-MDCK efflux ratio (B-A/A-B)\", \n",
-    "            user_attributes={\"Unit\": \"\tmL/min/kg\"}\n",
+    "            user_attributes={\"Unit\": \"mL/min/kg\"}\n",
     "        )\n",
     "    },\n",
     "    \n",

--- a/docs/tutorials/create_a_model.ipynb
+++ b/docs/tutorials/create_a_model.ipynb
@@ -59,19 +59,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import polaris as po\n",
+    "from polaris import load_benchmark, load_model\n",
     "\n",
     "# Load a benchmark\n",
-    "benchmark = po.load_benchmark(\"polaris/hello-world\")\n",
+    "benchmark = load_benchmark(\"polaris/hello-world-benchmark\")\n",
     "\n",
     "# Get the results\n",
     "results = benchmark.evaluate(...)\n",
     "\n",
     "# Attach it to the result\n",
-    "results.model = po.load_model(\"recursion/MolGPS\")\n",
+    "results.model = load_model(\"recursion/MolGPS\")\n",
     "\n",
     "# Upload the results\n",
-    "results.upload_to_hub(owner=\"dummy-user\")"
+    "results.upload_to_hub(owner=\"your-username\")"
    ]
   },
   {
@@ -99,7 +99,7 @@
     ")\n",
     "\n",
     "# Upload the results\n",
-    "results.upload_to_hub(owner=\"dummy-user\")"
+    "results.upload_to_hub(owner=\"your-username\")"
    ]
   },
   {

--- a/docs/tutorials/create_a_model.ipynb
+++ b/docs/tutorials/create_a_model.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A model in Polaris centralizes all data about a method and can be attached to different results.\n",
+    "\n",
+    "## Create a Model\n",
+    "\n",
+    "To create a model, you need to instantiate the `Model` class. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from polaris.model import Model\n",
+    "\n",
+    "# Create a new Model Card\n",
+    "model = Model(\n",
+    "    name=\"MolGPS\", \n",
+    "    description=\"Graph transformer foundation model for molecular modeling\",\n",
+    "    code_url=\"https://github.com/datamol-io/graphium\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Share your model\n",
+    "Want to share your model with the community? Upload it to the Polaris Hub!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.upload_to_hub(owner=\"your-username\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Attach a model with a result\n",
+    "\n",
+    "The model card can then be attached to a newly created result on upload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import polaris as po\n",
+    "\n",
+    "# Load a benchmark\n",
+    "benchmark = po.load_benchmark(\"polaris/hello-world\")\n",
+    "\n",
+    "# Get the results\n",
+    "results = benchmark.evaluate(...)\n",
+    "\n",
+    "# Attach it to the result\n",
+    "results.model = po.load_model(\"recursion/MolGPS\")\n",
+    "\n",
+    "# Upload the results\n",
+    "results.upload_to_hub(owner=\"dummy-user\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, you could also do"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the results\n",
+    "results = benchmark.evaluate(...)\n",
+    "\n",
+    "# Attach it to the result\n",
+    "results.model = Model(\n",
+    "    name=\"MolGPS\",\n",
+    "    owner=\"recursion\",\n",
+    "    description=\"Graph transformer foundation model for molecular modeling\",\n",
+    "    code_url=\"https://github.com/datamol-io/graphium\"\n",
+    ")\n",
+    "\n",
+    "# Upload the results\n",
+    "results.upload_to_hub(owner=\"dummy-user\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "The End. "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/tutorials/create_a_model.ipynb
+++ b/docs/tutorials/create_a_model.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,34 +69,6 @@
     "\n",
     "# Attach it to the result\n",
     "results.model = load_model(\"recursion/MolGPS\")\n",
-    "\n",
-    "# Upload the results\n",
-    "results.upload_to_hub(owner=\"your-username\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, you could also do"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get the results\n",
-    "results = benchmark.evaluate(...)\n",
-    "\n",
-    "# Attach it to the result\n",
-    "results.model = Model(\n",
-    "    name=\"MolGPS\",\n",
-    "    owner=\"recursion\",\n",
-    "    description=\"Graph transformer foundation model for molecular modeling\",\n",
-    "    code_url=\"https://github.com/datamol-io/graphium\"\n",
-    ")\n",
     "\n",
     "# Upload the results\n",
     "results.upload_to_hub(owner=\"your-username\")"

--- a/polaris/dataset/_subset.py
+++ b/polaris/dataset/_subset.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 from typing import Callable, Iterable, List, Literal, Sequence
 
 import numpy as np
@@ -225,7 +225,7 @@ class Subset:
 
     def copy(self) -> Self:
         """Returns a copy of the subset."""
-        return deepcopy(self)
+        return copy(self)
 
     def extend_inputs(self, input_cols: Iterable[str] | str) -> Self:
         """

--- a/polaris/evaluate/_metadata.py
+++ b/polaris/evaluate/_metadata.py
@@ -20,7 +20,7 @@ class ResultsMetadataV1(BaseArtifactModel):
     """
 
     # Additional metadata
-    github_url: HttpUrlString | None = None
+    github_url: HttpUrlString | None = Field(None, alias="code_url")
     paper_url: HttpUrlString | None = None
     contributors: list[HubUser] = Field(default_factory=list)
 

--- a/polaris/evaluate/_metadata.py
+++ b/polaris/evaluate/_metadata.py
@@ -21,7 +21,7 @@ class ResultsMetadataV1(BaseArtifactModel):
 
     # Additional metadata
     github_url: HttpUrlString | None = Field(None, alias="code_url")
-    paper_url: HttpUrlString | None = None
+    paper_url: HttpUrlString | None = Field(None, alias="report_url")
     contributors: list[HubUser] = Field(default_factory=list)
 
     # Private attributes

--- a/polaris/evaluate/_metadata.py
+++ b/polaris/evaluate/_metadata.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, computed_field
 
 from polaris._artifact import BaseArtifactModel
 from polaris.utils.dict2html import dict2html
@@ -51,6 +51,11 @@ class ResultsMetadataV2(BaseArtifactModel):
 
     # Private attributes
     _created_at: datetime = PrivateAttr(default_factory=datetime.now)
+
+    @computed_field
+    @property
+    def model_artifact_id(self) -> str:
+        return self.model.artifact_id
 
     def _repr_html_(self) -> str:
         return dict2html(self.model_dump())

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -891,6 +891,24 @@ class PolarisHubClient(OAuth2Client):
             )
             return response
 
+    def list_models(self, limit: int = 100, offset: int = 0) -> list[str]:
+        """List all available models on the Polaris Hub.
+
+        Args:
+            limit: The maximum number of models to return.
+            offset: The offset from which to start returning models.
+
+        Returns:
+            A list of models names in the format `owner/model_slug`.
+        """
+        with track_progress(description="Fetching models", total=1):
+            json_response = self._base_request_to_hub(
+                url="/v2/model", method="GET", params={"limit": limit, "offset": offset}
+            ).json()
+            models = [model["artifactId"] for model in json_response["data"]]
+
+            return models
+
     def get_model(self, artifact_id: str) -> Model:
         url = f"/v2/model/{artifact_id}"
         response = self._base_request_to_hub(url=url, method="GET")

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -492,7 +492,7 @@ class PolarisHubClient(OAuth2Client):
         with StorageSession(self, "read", BenchmarkV2Specification.urn_for(owner, name)) as storage:
             split = {label: storage.get_file(label) for label in response_data.get("split", {}).keys()}
 
-        return BenchmarkV2Specification(**response_data, split=split)
+        return BenchmarkV2Specification(**{**response_data, "split": split})
 
     def upload_results(
         self,

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -946,9 +946,8 @@ class PolarisHubClient(OAuth2Client):
             model_json = model.model_dump(by_alias=True, exclude_none=True)
 
             # Make a request to the Hub
-            response = self._base_request_to_hub(
-                url="/v2/model", method="POST", json={"access": access, **model_json}
-            )
+            url = f"/v2/model/{model.artifact_id}"
+            response = self._base_request_to_hub(url=url, method="PUT", json={"access": access, **model_json})
 
             # Inform the user about where to find their newly created artifact.
             model_url = urljoin(self.settings.hub_url, response.headers.get("Content-Location"))

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -399,7 +399,7 @@ class PolarisHubClient(OAuth2Client):
                 url="/v2/benchmark", method="GET", params={"limit": limit, "offset": offset}
             ).json()
             v2_data = v2_json_response["data"]
-            v2_benchmarks = [f"{HubOwner(**benchmark['owner'])}/{benchmark['name']}" for benchmark in v2_data]
+            v2_benchmarks = [benchmark["artifactId"] for benchmark in v2_data]
 
             # If v2 benchmarks satisfy the limit, return them
             if len(v2_benchmarks) == limit:
@@ -417,7 +417,7 @@ class PolarisHubClient(OAuth2Client):
                 },
             ).json()
             v1_data = v1_json_response["data"]
-            v1_benchmarks = [f"{HubOwner(**benchmark['owner'])}/{benchmark['name']}" for benchmark in v1_data]
+            v1_benchmarks = [benchmark["artifactId"] for benchmark in v1_data]
 
             # Combine the v2 and v1 benchmarks
             combined_benchmarks = v2_benchmarks + v1_benchmarks

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -265,7 +265,7 @@ class PolarisHubClient(OAuth2Client):
             offset: The offset from which to start returning datasets.
 
         Returns:
-            A list of dataset names in the format `owner/dataset_name`.
+            A list of dataset names in the format `owner/dataset_slug`.
         """
         with track_progress(description="Fetching datasets", total=1):
             # Step 1: Fetch enough v2 datasets to cover the offset and limit
@@ -383,14 +383,15 @@ class PolarisHubClient(OAuth2Client):
         return dataset
 
     def list_benchmarks(self, limit: int = 100, offset: int = 0) -> list[str]:
-        """List all available benchmarks on the Polaris Hub.
+        """List all available benchmarks (v1 and v2) on the Polaris Hub.
+        We prioritize v2 benchmarks over v1 benchmarks.
 
         Args:
             limit: The maximum number of benchmarks to return.
             offset: The offset from which to start returning benchmarks.
 
         Returns:
-            A list of benchmark names in the format `owner/benchmark_name`.
+            A list of benchmark names in the format `owner/benchmark_slug`.
         """
         with track_progress(description="Fetching benchmarks", total=1):
             # Step 1: Fetch enough v2 benchmarks to cover the offset and limit

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -24,7 +24,7 @@ from polaris.benchmark._benchmark_v2 import BenchmarkV2Specification
 from polaris.competition import CompetitionSpecification
 from polaris.model import Model
 from polaris.dataset import Dataset, DatasetV1, DatasetV2
-from polaris.evaluate import BenchmarkResults, CompetitionPredictions
+from polaris.evaluate import BenchmarkResultsV1, BenchmarkResultsV2, CompetitionPredictions
 from polaris.hub.external_client import ExternalAuthClient
 from polaris.hub.oauth import CachedTokenAuth
 from polaris.hub.settings import PolarisHubSettings
@@ -496,7 +496,7 @@ class PolarisHubClient(OAuth2Client):
 
     def upload_results(
         self,
-        results: BenchmarkResults,
+        results: BenchmarkResultsV1 | BenchmarkResultsV2,
         access: AccessType = "private",
         owner: HubOwner | str | None = None,
     ):


### PR DESCRIPTION
## Changelogs

- **New Features:**
  - Added `list_models` utility function.
  - Introduced a **"Create a Model"** tutorial.
  - Added `model_artifact_id` as a computed property in `ResultsMetadataV2`.
  
- **Improvements:**
  - Added `code_url` as an alias for `github_url` in `ResultsMetadataV1`.
  - Added `report_url` as an alias for `paper_url` in `ResultsMetadataV1`.
 
- **Bug Fixes:**
  - Fixed a bug in result evaluation by using a shallow copy of subsets instead of a deep copy.
  - Fixed a bug in the `get_model` method (wrong endpoint URL).
  - Fixed a bug in the `_get_v2_benchmark` method (`TypeError: got multiple values for keyword argument 'split'`)
  - Fixed typings in the `upload_results` method for `results` param.
  - Corrected small typos in docstrings.

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

## Demo Videos

<details>
<summary><b>Model Landing and Detail Pages / Leaderboard</b></summary>

https://github.com/user-attachments/assets/de858c5f-56f0-46c4-b07d-61a192b5ca4b
</details>

<details>
<summary><b>Create a Model</b></summary>

https://github.com/user-attachments/assets/7443bb50-87b5-4cdb-88ff-d9647771a84b
</details>

<details>
<summary><b>Attach a Model to results</b></summary>

https://github.com/user-attachments/assets/6ccd92cc-8de3-4199-9a18-80860b8487c9
</details>

<details>
<summary><b>List models/Load a specific Model</b></summary>

https://github.com/user-attachments/assets/6247e470-1f82-4bd3-a10b-686c1a0253a1
</details>
