### PR TITLE
fix: Extras are not recognized and installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,32 @@ codecs = [
     "imagecodecs",
 ]
 
+# PEP 735 Dependency Groups are not well-supported by pip.
+# Duplicate them here with the older syntax.
+[project.optional-dependencies]
+dev = [
+    "ipywidgets",
+    "jupyterlab",
+    "moto[s3]>=5.0.14",
+    "pytest >=7",
+    "pytest-xdist",
+    "pytest-cov",
+    "ruff",
+]
+doc = [
+    "mkdocs",
+    "mkdocs-material >=9.4.7",
+    "mkdocstrings",
+    "mkdocstrings-python",
+    "mkdocs-jupyter",
+    "markdown-include",
+    "mdx_truly_sane_lists",
+    "mike >=1.0.0",
+    "nbconvert",
+]
+codecs = [
+    "imagecodecs",
+]
 
 [project.scripts]
 polaris = "polaris.cli:app"


### PR DESCRIPTION
## Changelogs

- Add a `project.optional-dependencies` to the `pyproject.toml` file

---

_Checklist:_

- [X] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] ~_Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._~
- [ ] ~_Update the API documentation if a new function is added, or an existing one is deleted._~
- [X] _Write concise and explanatory changelogs above._
- [X] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

Adresses #274

Using the [PEP 735](https://peps.python.org/pep-0735/) to define dependency groups means they are not recognized as extras when Polaris is specified as a dependency. So doing `pip install 
polaris-lib[codecs]` will not also install `imagecodecs` as a dependency.

We probably have not noticied this behavior when developping the library locally because `uv sync` recognizes the dependency groups.
