### PR TITLE
chore: Replace `Union` with `|` in type annotations

### DIFF
--- a/polaris/dataset/converters/_base.py
+++ b/polaris/dataset/converters/_base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, Tuple, TypeAlias, Union
+from typing import Dict, Tuple, TypeAlias
 
 import pandas as pd
 
@@ -17,7 +17,7 @@ class Converter(abc.ABC):
         raise NotImplementedError
 
     @staticmethod
-    def get_pointer(column: str, index: Union[int, slice]) -> str:
+    def get_pointer(column: str, index: int | slice) -> str:
         """
         Creates a pointer.
 

--- a/polaris/dataset/converters/_pdb.py
+++ b/polaris/dataset/converters/_pdb.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Sequence
 
 import fastpdb
 import numpy as np
@@ -156,7 +156,7 @@ class PDBConverter(Converter):
         return pdb_dict
 
     def _convert_pdb(
-        self, path: str, factory: "DatasetFactory", pdb_pointer: Union[str, int], append: bool = False
+        self, path: str, factory: "DatasetFactory", pdb_pointer: str | int, append: bool = False
     ) -> FactoryProduct:
         """
         Convert a single pdb to zarr file

--- a/polaris/evaluate/metrics/docking_metrics.py
+++ b/polaris/evaluate/metrics/docking_metrics.py
@@ -1,6 +1,6 @@
 # This script includes docking related evaluation metrics.
 
-from typing import Union, List
+from typing import List
 
 import numpy as np
 from rdkit.Chem.rdMolAlign import CalcRMS
@@ -36,7 +36,7 @@ def _rmsd(mol_probe: dm.Mol, mol_ref: dm.Mol) -> float:
     )
 
 
-def rmsd_coverage(y_pred: Union[str, List[dm.Mol]], y_true: Union[str, list[dm.Mol]], max_rsmd: float = 2):
+def rmsd_coverage(y_pred: str | List[dm.Mol], y_true: str | list[dm.Mol], max_rsmd: float = 2):
     """
     Calculate the coverage of molecules with an RMSD less than a threshold (2 Å by default) compared to the reference molecule conformer.
 

--- a/polaris/hub/settings.py
+++ b/polaris/hub/settings.py
@@ -1,4 +1,3 @@
-from typing import Union
 from urllib.parse import urljoin
 
 from pydantic import ValidationInfo, field_validator
@@ -57,7 +56,7 @@ class PolarisHubSettings(BaseSettings):
     client_id: str = "agQP2xVM6JqMHvGc"
 
     # Networking settings
-    ca_bundle: Union[str, bool, None] = None
+    ca_bundle: str | bool | None = None
     default_timeout: TimeoutTypes = (10, 200)
 
     @field_validator("api_url", mode="before")

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Annotated, Any, Literal, Optional, Tuple, Union
+from typing import Annotated, Any, Literal, Optional, Tuple
 
 import numpy as np
 from pydantic import (
@@ -19,7 +19,7 @@ SplitIndicesType: TypeAlias = list[int]
 A split is defined by a sequence of integers.
 """
 
-SplitType: TypeAlias = tuple[SplitIndicesType, Union[SplitIndicesType, dict[str, SplitIndicesType]]]
+SplitType: TypeAlias = tuple[SplitIndicesType, SplitIndicesType | dict[str, SplitIndicesType]]
 """
 A split is a pair of which the first item is always assumed to be the train set.
 The second item can either be a single test set or a dictionary with multiple, named test sets.
@@ -47,7 +47,7 @@ variety of representations and normalized into this standard format, a dictionar
 that looks like {"test_set_name": {"target_name": np.ndarray}}.
 """
 
-DatapointPartType = Union[Any, tuple[Any], dict[str, Any]]
+DatapointPartType = Any | tuple[Any] | dict[str, Any]
 DatapointType: TypeAlias = tuple[DatapointPartType, DatapointPartType]
 """
 A datapoint has:
@@ -109,7 +109,7 @@ AccessType: TypeAlias = Literal["public", "private"]
 Type to specify access to a dataset, benchmark or result in the Hub.
 """
 
-TimeoutTypes = Union[Tuple[int, int], Literal["timeout", "never"]]
+TimeoutTypes = Tuple[int, int] | Literal["timeout", "never"]
 """
 Timeout types for specifying maximum wait times.
 """
@@ -150,7 +150,7 @@ To index a dataset using square brackets, we have a few options:
 - A single row, e.g. dataset[0]
 - Specify a specific value, e.g. dataset[0, "col1"]
 
-There are more exciting options we could implement, such as slicing, 
+There are more exciting options we could implement, such as slicing,
 but this gets complex.
 """
 


### PR DESCRIPTION
## Changelogs

- Replaces all usage of typing `Union` with `|`

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._