### PR TITLE
fix: Allow models to be optional on results v2

### DIFF
--- a/polaris/evaluate/_metadata.py
+++ b/polaris/evaluate/_metadata.py
@@ -55,7 +55,7 @@ class ResultsMetadataV2(BaseArtifactModel):
     @computed_field
     @property
     def model_artifact_id(self) -> str:
-        return self.model.artifact_id
+        return self.model.artifact_id if self.model else None
 
     def _repr_html_(self) -> str:
         return dict2html(self.model_dump())


### PR DESCRIPTION
## Changelogs

Since we're making [models optional when uploading a v2 result](https://github.com/polaris-hub/polaris-hub/pull/634), this change needs to be made. Otherwise, an error gets thrown when no model is included 😊

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the newly introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs above._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix`, `chore`, `documentation` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
