### PR TITLE
Refactor/Chore: Remove access parameters in client

### DIFF
--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -185,9 +185,7 @@ class BenchmarkSpecification(
             cache_auth_token=cache_auth_token,
             **kwargs,
         ) as client:
-            return client.upload_benchmark(
-                self, owner=owner, parent_artifact_id=parent_artifact_id
-            )
+            return client.upload_benchmark(self, owner=owner, parent_artifact_id=parent_artifact_id)
 
     def to_json(self, destination: str) -> str:
         """Save the benchmark to a destination directory as a JSON file.

--- a/polaris/benchmark/_base.py
+++ b/polaris/benchmark/_base.py
@@ -29,7 +29,6 @@ from polaris.mixins import ChecksumMixin
 from polaris.utils.dict2html import dict2html
 from polaris.utils.errors import InvalidBenchmarkError
 from polaris.utils.types import (
-    AccessType,
     HubOwner,
     IncomingPredictionsType,
     TargetType,
@@ -171,7 +170,6 @@ class BenchmarkSpecification(
         self,
         settings: PolarisHubSettings | None = None,
         cache_auth_token: bool = True,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
         **kwargs: dict,
@@ -188,7 +186,7 @@ class BenchmarkSpecification(
             **kwargs,
         ) as client:
             return client.upload_benchmark(
-                self, access=access, owner=owner, parent_artifact_id=parent_artifact_id
+                self, owner=owner, parent_artifact_id=parent_artifact_id
             )
 
     def to_json(self, destination: str) -> str:

--- a/polaris/dataset/_base.py
+++ b/polaris/dataset/_base.py
@@ -29,7 +29,6 @@ from polaris.utils.context import track_progress
 from polaris.utils.dict2html import dict2html
 from polaris.utils.errors import InvalidDatasetError
 from polaris.utils.types import (
-    AccessType,
     ChecksumStrategy,
     DatasetIndex,
     HttpUrlString,
@@ -304,7 +303,6 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
     @abc.abstractmethod
     def upload_to_hub(
         self,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):

--- a/polaris/dataset/_dataset.py
+++ b/polaris/dataset/_dataset.py
@@ -18,7 +18,6 @@ from polaris.dataset.zarr import ZarrFileChecksum, compute_zarr_checksum
 from polaris.mixins._checksum import ChecksumMixin
 from polaris.utils.errors import InvalidDatasetError
 from polaris.utils.types import (
-    AccessType,
     ChecksumStrategy,
     HubOwner,
     ZarrConflictResolution,
@@ -220,7 +219,6 @@ class DatasetV1(BaseDataset, ChecksumMixin):
 
     def upload_to_hub(
         self,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
@@ -231,7 +229,7 @@ class DatasetV1(BaseDataset, ChecksumMixin):
         from polaris.hub.client import PolarisHubClient
 
         with PolarisHubClient() as client:
-            client.upload_dataset(self, owner=owner, access=access, parent_artifact_id=parent_artifact_id)
+            client.upload_dataset(self, owner=owner, parent_artifact_id=parent_artifact_id)
 
     @classmethod
     def from_json(cls, path: str):

--- a/polaris/dataset/_dataset_v2.py
+++ b/polaris/dataset/_dataset_v2.py
@@ -15,7 +15,7 @@ from polaris.dataset._adapters import Adapter
 from polaris.dataset._base import BaseDataset
 from polaris.dataset.zarr._manifest import calculate_file_md5, generate_zarr_manifest
 from polaris.utils.errors import InvalidDatasetError
-from polaris.utils.types import AccessType, ChecksumStrategy, HubOwner, ZarrConflictResolution
+from polaris.utils.types import ChecksumStrategy, HubOwner, ZarrConflictResolution
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +194,6 @@ class DatasetV2(BaseDataset):
 
     def upload_to_hub(
         self,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
@@ -205,7 +204,7 @@ class DatasetV2(BaseDataset):
         from polaris.hub.client import PolarisHubClient
 
         with PolarisHubClient() as client:
-            client.upload_dataset(self, owner=owner, access=access, parent_artifact_id=parent_artifact_id)
+            client.upload_dataset(self, owner=owner, parent_artifact_id=parent_artifact_id)
 
     @classmethod
     def from_json(cls, path: str):

--- a/polaris/evaluate/_results.py
+++ b/polaris/evaluate/_results.py
@@ -16,7 +16,6 @@ from polaris.evaluate import ResultsMetadataV1, ResultsMetadataV2
 from polaris.utils.errors import InvalidResultError
 from polaris.utils.misc import slugify
 from polaris.utils.types import (
-    AccessType,
     HubOwner,
     SlugCompatibleStringType,
 )
@@ -173,7 +172,6 @@ class BaseBenchmarkResults:
 
     def upload_to_hub(
         self,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         **kwargs: dict,
     ):
@@ -184,7 +182,7 @@ class BaseBenchmarkResults:
         from polaris.hub.client import PolarisHubClient
 
         with PolarisHubClient(**kwargs) as client:
-            return client.upload_results(self, access=access, owner=owner)
+            return client.upload_results(self, owner=owner)
 
 
 class BenchmarkResultsV1(EvaluationResultV1, BaseBenchmarkResults):

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -521,7 +521,7 @@ class PolarisHubClient(OAuth2Client):
             result_json = results.model_dump(by_alias=True, exclude_none=True)
 
             # Make a request to the Hub
-            response = self._base_request_to_hub(url="/v2/result", method="POST", json={**result_json})
+            response = self._base_request_to_hub(url="/v2/result", method="POST", json=result_json)
 
             # Inform the user about where to find their newly created artifact.
             result_url = urljoin(self.settings.hub_url, response.headers.get("Content-Location"))

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -39,7 +39,6 @@ from polaris.utils.errors import (
     PolarisUnauthorizedError,
 )
 from polaris.utils.types import (
-    AccessType,
     ChecksumStrategy,
     HubOwner,
     SupportedLicenseType,
@@ -497,7 +496,6 @@ class PolarisHubClient(OAuth2Client):
     def upload_results(
         self,
         results: BenchmarkResultsV1 | BenchmarkResultsV2,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
     ):
         """Upload the results to the Polaris Hub.
@@ -515,7 +513,6 @@ class PolarisHubClient(OAuth2Client):
 
         Args:
             results: The results to upload.
-            access: Grant public or private access to result
             owner: Which Hub user or organization owns the artifact. Takes precedence over `results.owner`.
         """
         with track_progress(description="Uploading results", total=1) as (progress, task):
@@ -525,7 +522,7 @@ class PolarisHubClient(OAuth2Client):
 
             # Make a request to the Hub
             response = self._base_request_to_hub(
-                url="/v2/result", method="POST", json={"access": access, **result_json}
+                url="/v2/result", method="POST", json={**result_json}
             )
 
             # Inform the user about where to find their newly created artifact.
@@ -538,7 +535,6 @@ class PolarisHubClient(OAuth2Client):
     def upload_dataset(
         self,
         dataset: DatasetV1 | DatasetV2,
-        access: AccessType = "private",
         timeout: TimeoutTypes = (10, 200),
         owner: HubOwner | str | None = None,
         if_exists: ZarrConflictResolution = "replace",
@@ -558,7 +554,6 @@ class PolarisHubClient(OAuth2Client):
 
         Args:
             dataset: The dataset to upload.
-            access: Grant public or private access to result
             timeout: Request timeout values. User can modify the value when uploading large dataset as needed.
                 This can be a single value with the timeout in seconds for all IO operations, or a more granular
                 tuple with (connect_timeout, write_timeout). The type of the the timout parameter comes from `httpx`.
@@ -580,15 +575,14 @@ class PolarisHubClient(OAuth2Client):
             )
 
         if isinstance(dataset, DatasetV1):
-            self._upload_v1_dataset(dataset, timeout, access, owner, if_exists, parent_artifact_id)
+            self._upload_v1_dataset(dataset, timeout, owner, if_exists, parent_artifact_id)
         elif isinstance(dataset, DatasetV2):
-            self._upload_v2_dataset(dataset, timeout, access, owner, if_exists, parent_artifact_id)
+            self._upload_v2_dataset(dataset, timeout, owner, if_exists, parent_artifact_id)
 
     def _upload_v1_dataset(
         self,
         dataset: DatasetV1,
         timeout: TimeoutTypes,
-        access: AccessType,
         owner: HubOwner | str | None,
         if_exists: ZarrConflictResolution,
         parent_artifact_id: str | None,
@@ -632,7 +626,6 @@ class PolarisHubClient(OAuth2Client):
                         "md5Sum": parquet_md5,
                     },
                     "zarrContent": [md5sum.model_dump() for md5sum in dataset._zarr_md5sum_manifest],
-                    "access": access,
                     "parentArtifactId": parent_artifact_id,
                     **dataset_json,
                 },
@@ -677,7 +670,6 @@ class PolarisHubClient(OAuth2Client):
         self,
         dataset: DatasetV2,
         timeout: TimeoutTypes,
-        access: AccessType,
         owner: HubOwner | str | None,
         if_exists: ZarrConflictResolution,
         parent_artifact_id: str | None,
@@ -700,7 +692,6 @@ class PolarisHubClient(OAuth2Client):
                     "zarrManifestFileContent": {
                         "md5Sum": dataset.zarr_manifest_md5sum,
                     },
-                    "access": access,
                     "parentArtifactId": parent_artifact_id,
                     **dataset_json,
                 },
@@ -748,7 +739,6 @@ class PolarisHubClient(OAuth2Client):
     def upload_benchmark(
         self,
         benchmark: BenchmarkV1Specification | BenchmarkV2Specification,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
@@ -770,20 +760,18 @@ class PolarisHubClient(OAuth2Client):
 
         Args:
             benchmark: The benchmark to upload.
-            access: Grant public or private access to result
             owner: Which Hub user or organization owns the artifact. Takes precedence over `benchmark.owner`.
             parent_artifact_id: The `owner/slug` of the parent benchmark, if uploading a new version of a benchmark.
         """
         match benchmark:
             case BenchmarkV1Specification():
-                self._upload_v1_benchmark(benchmark, access, owner, parent_artifact_id)
+                self._upload_v1_benchmark(benchmark, owner, parent_artifact_id)
             case BenchmarkV2Specification():
-                self._upload_v2_benchmark(benchmark, access, owner, parent_artifact_id)
+                self._upload_v2_benchmark(benchmark, owner, parent_artifact_id)
 
     def _upload_v1_benchmark(
         self,
         benchmark: BenchmarkV1Specification,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
@@ -796,7 +784,6 @@ class PolarisHubClient(OAuth2Client):
             benchmark.owner = HubOwner.normalize(owner or benchmark.owner)
             benchmark_json = benchmark.model_dump(exclude={"dataset"}, exclude_none=True, by_alias=True)
             benchmark_json["datasetArtifactId"] = benchmark.dataset.artifact_id
-            benchmark_json["access"] = access
 
             url = f"/v1/benchmark/{benchmark.artifact_id}"
             response = self._base_request_to_hub(
@@ -811,7 +798,6 @@ class PolarisHubClient(OAuth2Client):
     def _upload_v2_benchmark(
         self,
         benchmark: BenchmarkV2Specification,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
@@ -834,7 +820,6 @@ class PolarisHubClient(OAuth2Client):
                 url=url,
                 method="PUT",
                 json={
-                    "access": access,
                     "datasetArtifactId": benchmark.dataset.artifact_id,
                     "parentArtifactId": parent_artifact_id,
                     **benchmark_json,
@@ -940,7 +925,6 @@ class PolarisHubClient(OAuth2Client):
     def upload_model(
         self,
         model: Model,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
@@ -958,7 +942,6 @@ class PolarisHubClient(OAuth2Client):
 
         Args:
             model: The model to upload.
-            access: Grant public or private access to result
             owner: Which Hub user or organization owns the artifact. Takes precedence over `model.owner`.
             parent_artifact_id: The `owner/slug` of the parent model, if uploading a new version of a model.
         """
@@ -972,7 +955,7 @@ class PolarisHubClient(OAuth2Client):
             response = self._base_request_to_hub(
                 url=url,
                 method="PUT",
-                json={"access": access, "parentArtifactId": parent_artifact_id, **model_json},
+                json={"parentArtifactId": parent_artifact_id, **model_json},
             )
 
             # NOTE: When we merge in the competition model feature, we will need to update the slug with the inserted model slug to make sure we write to the correct storage location.

--- a/polaris/hub/client.py
+++ b/polaris/hub/client.py
@@ -521,9 +521,7 @@ class PolarisHubClient(OAuth2Client):
             result_json = results.model_dump(by_alias=True, exclude_none=True)
 
             # Make a request to the Hub
-            response = self._base_request_to_hub(
-                url="/v2/result", method="POST", json={**result_json}
-            )
+            response = self._base_request_to_hub(url="/v2/result", method="POST", json={**result_json})
 
             # Inform the user about where to find their newly created artifact.
             result_url = urljoin(self.settings.hub_url, response.headers.get("Content-Location"))

--- a/polaris/model/__init__.py
+++ b/polaris/model/__init__.py
@@ -1,6 +1,6 @@
 from polaris._artifact import BaseArtifactModel
 from polaris.utils.types import HttpUrlString
-from polaris.utils.types import AccessType, HubOwner
+from polaris.utils.types import HubOwner
 from pydantic import Field
 
 
@@ -35,8 +35,8 @@ class Model(BaseArtifactModel):
         artifact_changelog: A description of the changes made in this model version.
 
     Methods:
-        upload_to_hub(access: AccessType = "private", owner: HubOwner | str | None = None):
-            Uploads the model artifact to the Polaris Hub, associating it with a specified owner and access level.
+        upload_to_hub(owner: HubOwner | str | None = None):
+            Uploads the model artifact to the Polaris Hub, associating it with a specified owner.
 
     For additional metadata attributes, see the base class.
     """
@@ -53,7 +53,6 @@ class Model(BaseArtifactModel):
 
     def upload_to_hub(
         self,
-        access: AccessType = "private",
         owner: HubOwner | str | None = None,
         parent_artifact_id: str | None = None,
     ):
@@ -63,4 +62,4 @@ class Model(BaseArtifactModel):
         from polaris.hub.client import PolarisHubClient
 
         with PolarisHubClient() as client:
-            client.upload_model(self, owner=owner, access=access, parent_artifact_id=parent_artifact_id)
+            client.upload_model(self, owner=owner, parent_artifact_id=parent_artifact_id)

--- a/polaris/utils/types.py
+++ b/polaris/utils/types.py
@@ -104,11 +104,6 @@ The direction of any variable to be sorted.
 This can be used to sort the metric score, indicate the optmization direction of endpoint.
 """
 
-AccessType: TypeAlias = Literal["public", "private"]
-"""
-Type to specify access to a dataset, benchmark or result in the Hub.
-"""
-
 TimeoutTypes = tuple[int, int] | Literal["timeout", "never"]
 """
 Timeout types for specifying maximum wait times.


### PR DESCRIPTION
This PR removes the `AccessType` type, simplifying the API by eliminating the `access` parameter, which was previously used to specify public or private access when uploading artifacts to the Polaris Hub.

### Removal of `AccessType` and `access` parameter:

* **Type and Imports Cleanup**:
  - Removed `AccessType` from imports in multiple files, including `polaris/benchmark/_base.py`, `polaris/dataset/_base.py`, `polaris/dataset/_dataset.py`, `polaris/dataset/_dataset_v2.py`, `polaris/evaluate/_results.py`, `polaris/hub/client.py`, and `polaris/model/__init__.py`.

* **Parameter Removal in Method Definitions**:
  - Removed the `access` parameter from method signatures such as `upload_to_hub` in various modules (`polaris/benchmark/_base.py`, `polaris/dataset/_base.py`, `polaris/dataset/_dataset.py`, `polaris/dataset/_dataset_v2.py`, `polaris/evaluate/_results.py`, `polaris/hub/client.py`, and `polaris/model/__init__.py`). 

* **Documentation Updates**:
  - Adjusted method docstrings to remove mentions of the `access` parameter, ensuring the documentation aligns with the updated API.
  
  Notion Package: https://www.notion.so/Private-Artifact-Removal-1ec0c0d8de7080cf9b6fdde6b7fc0dd8 