### PR TITLE
Feat/add prediction artifact and upload method

### DIFF
--- a/polaris/evaluate/__init__.py
+++ b/polaris/evaluate/__init__.py
@@ -29,4 +29,5 @@ __all__ = [
     "evaluate_benchmark",
     "CompetitionPredictions",
     "BenchmarkPredictions",
+    "Predictions",
 ]


### PR DESCRIPTION
## Summary of Changes

This PR introduces a new Prediction artifact, and an associated upload method 

### New Features
- **Prediction Artifact (`Predictions`)**
  - Added a new `Predictions` model to represent prediction artifacts as Zarr archives.
  - Includes validators to ensure Zarr structure consistency.
  - Provides convenient properties (`columns`, `dtypes`, `n_rows`, etc.) for quick data exploration.
  - Methods for setting/getting prediction values, creating Zarr archives from dicts, and uploading to the Polaris Hub.

- **Upload API (`upload_prediction`)**
  - Added a new `upload_prediction` method in `PolarisHubClient` for uploading prediction artifacts.
  - Handles metadata, manifest, and archive uploads with progress tracking.

---