### PR TITLE
fix: consolidate Zarr metadata after caching to fix to_json serialization (Fixes #303)

### DIFF
--- a/polaris/dataset/_base.py
+++ b/polaris/dataset/_base.py
@@ -404,3 +404,9 @@ class BaseDataset(BaseArtifactModel, abc.ABC):
             self.zarr_root_path = str(destination_zarr_root)
             self._zarr_root = None
             self._zarr_data = None
+
+        # Consolidate the metadata of the cached copy so that
+        # subsequent calls to load_zarr_root_from_local() (which
+        # uses zarr.open_consolidated) work without raising
+        # InvalidDatasetError.  See: polaris-hub/polaris#303
+        zarr.consolidate_metadata(str(destination_zarr_root))


### PR DESCRIPTION
Fixes #303

## Problem

When calling `DatasetV2.to_json()` on a dataset loaded from the Polaris Hub, the `model_dump_json()` call fails with:

```
pydantic_core._pydantic_core.PydanticSerializationError: Error serializing to JSON: 
InvalidDatasetError: A Zarr archive associated with a Polaris dataset has to be consolidated.
```

**Root cause:** `_cache_zarr()` copies the Zarr archive to a local directory using either `S3Store.copy_to_destination()` or `zarr.copy_store()`, then updates `zarr_root_path` to point to the local copy. However, when `model_dump_json()` later accesses computed fields like `n_rows` and `n_columns`, these trigger the `zarr_root` property which calls `load_zarr_root_from_local()` → `zarr.open_consolidated()`. If the cached copy doesn't have `.zmetadata` (which can happen with Hub/S3 stores), this fails with a `KeyError` that gets wrapped as `InvalidDatasetError`.

## Solution

Add `zarr.consolidate_metadata()` after copying the Zarr archive in `_cache_zarr()`. This ensures the cached local copy always has consolidated metadata, regardless of whether the source store's copy mechanism preserved `.zmetadata`.

## Verification

- All 11 existing tests in `test_dataset_v2.py` pass (the 1 failure in `test_dataset_v1_v2_compatibility` is a pre-existing `numcodecs` issue unrelated to this change)
- Manually verified that `DatasetV2.to_json()` works after the fix
- Manually verified that without consolidated metadata, `zarr.open_consolidated()` fails, and after `zarr.consolidate_metadata()` it succeeds

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
